### PR TITLE
Remove yarn commands, use npm throughout repo

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-npm run lint-staged
+npx lint-staged

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+yarn lint-staged
+

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,0 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
-yarn lint-staged
-

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-yarn lint-staged
-
+npm run lint-staged

--- a/elements/openlayers-core/package.json
+++ b/elements/openlayers-core/package.json
@@ -17,7 +17,7 @@
   "license": "MIT",
   "scripts": {
     "build": "tsc",
-    "prepare": "yarn build"
+    "prepare": "npm run build"
   },
   "dependencies": {
     "lit": "^2.0.0",

--- a/elements/openlayers-elements/package.json
+++ b/elements/openlayers-elements/package.json
@@ -14,7 +14,7 @@
   "license": "MIT",
   "scripts": {
     "build": "tsc",
-    "prepare": "yarn build"
+    "prepare": "npm run build"
   },
   "dependencies": {
     "@openlayers-elements/core": "^0.3.0",

--- a/elements/openlayers-elements/readme.md
+++ b/elements/openlayers-elements/readme.md
@@ -10,7 +10,7 @@ See [documentation and demos](https://openlayers-elements.netlify.com).
 To install run
 
 ```
-yarn add @openlayers-elements/maps @openlayers-elements/core
+npm add @openlayers-elements/maps @openlayers-elements/core
 ```
 
 Here's the simplest possible OpenStreetMap:

--- a/elements/swisstopo-elements/readme.md
+++ b/elements/swisstopo-elements/readme.md
@@ -9,7 +9,7 @@ See [documentation and demos](https://openlayers-elements.netlify.com).
 To install run
 
 ```
-yarn add @openlayers-elements/swisstopo @openlayers-elements/core
+npm add @openlayers-elements/swisstopo @openlayers-elements/core
 ```
 
 Then add the WMTS layer to your `ol-map` 

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,6 @@
         "eslint-plugin-promise": "^6.0.0",
         "eslint-plugin-standard": "^5.0.0",
         "eslint-plugin-wc": "^1.3.2",
-        "husky": "^8.0.1",
         "lint-staged": "^13.0.3",
         "polymer-cli": "^1.9.11",
         "prettier": "^1.16.4",
@@ -14927,20 +14926,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14.18.0"
-      }
-    },
-    "node_modules/husky": {
-      "version": "8.0.3",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "husky": "lib/bin.js"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "eslint-plugin-promise": "^6.0.0",
         "eslint-plugin-standard": "^5.0.0",
         "eslint-plugin-wc": "^1.3.2",
+        "husky": "^8.0.1",
         "lint-staged": "^13.0.3",
         "polymer-cli": "^1.9.11",
         "prettier": "^1.16.4",
@@ -14926,6 +14927,20 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14.18.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "8.0.3",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "lib/bin.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "test": "wtr",
     "analyze": "polymer analyze --sources elements > demos/analysis.json",
     "docs": "npm run build; npm run analyze; wsrun -p demos -c build",
-    "release": "changeset publish"
+    "release": "changeset publish",
+    "prepare": "husky install"
   },
   "devDependencies": {
     "@changesets/cli": "^2.21.0",

--- a/package.json
+++ b/package.json
@@ -8,15 +8,14 @@
     "elements/*"
   ],
   "scripts": {
-    "prestart": "yarn analyze",
+    "prestart": "npm run analyze",
     "start": "wsrun -p demos -c start",
     "build": "wsrun -x demos -x @openlayers-elements/testing -c build",
     "lint": "eslint --ext .ts,.js elements demos --quiet",
     "test": "wtr",
     "analyze": "polymer analyze --sources elements > demos/analysis.json",
-    "docs": "yarn build; yarn analyze; wsrun -p demos -c build",
-    "release": "changeset publish",
-    "prepare": "husky install"
+    "docs": "npm run build; npm run analyze; wsrun -p demos -c build",
+    "release": "changeset publish"
   },
   "devDependencies": {
     "@changesets/cli": "^2.21.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "start": "wsrun -p demos -c start",
     "build": "wsrun -x demos -x @openlayers-elements/testing -c build",
     "lint": "eslint --ext .ts,.js elements demos --quiet",
+    "lint-staged": "lint-staged",
     "test": "wtr",
     "analyze": "polymer analyze --sources elements > demos/analysis.json",
     "docs": "npm run build; npm run analyze; wsrun -p demos -c build",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "start": "wsrun -p demos -c start",
     "build": "wsrun -x demos -x @openlayers-elements/testing -c build",
     "lint": "eslint --ext .ts,.js elements demos --quiet",
-    "lint-staged": "lint-staged",
     "test": "wtr",
     "analyze": "polymer analyze --sources elements > demos/analysis.json",
     "docs": "npm run build; npm run analyze; wsrun -p demos -c build",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "eslint-plugin-promise": "^6.0.0",
     "eslint-plugin-standard": "^5.0.0",
     "eslint-plugin-wc": "^1.3.2",
+    "husky": "^8.0.1",
     "lint-staged": "^13.0.3",
     "polymer-cli": "^1.9.11",
     "prettier": "^1.16.4",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "eslint-plugin-promise": "^6.0.0",
     "eslint-plugin-standard": "^5.0.0",
     "eslint-plugin-wc": "^1.3.2",
-    "husky": "^8.0.1",
     "lint-staged": "^13.0.3",
     "polymer-cli": "^1.9.11",
     "prettier": "^1.16.4",


### PR DESCRIPTION
### Issue

- `npm install` was failing due to usage of yarn commands.
- Following from https://github.com/openlayers-elements/openlayers-elements/commit/cd1558ee68e75dfdd6ea8628644226b09d045405, `yarn` is to be removed.

### Solution

- This PR removes all references to yarn in `package.json` files and docs.
- ~~Husky was also removed, as it was was causing an error on commit (there are better tools for pre-commit hooks if needed as of 2024)~~