### PR TITLE
Update OpenLayers --> v6.15.0

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,0 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
-yarn lint-staged
-

--- a/elements/openlayers-core/package.json
+++ b/elements/openlayers-core/package.json
@@ -17,7 +17,7 @@
   "license": "MIT",
   "scripts": {
     "build": "tsc",
-    "prepare": "yarn build"
+    "prepare": "npm run build"
   },
   "dependencies": {
     "lit": "^2.0.0",

--- a/elements/openlayers-core/package.json
+++ b/elements/openlayers-core/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "lit": "^2.0.0",
-    "ol": "^6.5.0",
+    "ol": "^6.6.0",
     "resize-observer-polyfill": "^1.5.1"
   },
   "devDependencies": {

--- a/elements/openlayers-core/package.json
+++ b/elements/openlayers-core/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "lit": "^2.0.0",
-    "ol": "^6.6.0",
+    "ol": "^6.15.0",
     "resize-observer-polyfill": "^1.5.1"
   },
   "devDependencies": {

--- a/elements/openlayers-elements/package.json
+++ b/elements/openlayers-elements/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@openlayers-elements/core": "^0.3.0",
     "lit": "^2.0.0",
-    "ol": "^6.6.0",
+    "ol": "^6.15.0",
     "resize-observer-polyfill": "^1.5.1"
   },
   "devDependencies": {

--- a/elements/openlayers-elements/package.json
+++ b/elements/openlayers-elements/package.json
@@ -14,7 +14,7 @@
   "license": "MIT",
   "scripts": {
     "build": "tsc",
-    "prepare": "yarn build"
+    "prepare": "npm run build"
   },
   "dependencies": {
     "@openlayers-elements/core": "^0.3.0",

--- a/elements/openlayers-elements/package.json
+++ b/elements/openlayers-elements/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@openlayers-elements/core": "^0.3.0",
     "lit": "^2.0.0",
-    "ol": "^6.5.0",
+    "ol": "^6.6.0",
     "resize-observer-polyfill": "^1.5.1"
   },
   "devDependencies": {

--- a/elements/openlayers-elements/readme.md
+++ b/elements/openlayers-elements/readme.md
@@ -10,7 +10,7 @@ See [documentation and demos](https://openlayers-elements.netlify.com).
 To install run
 
 ```
-yarn add @openlayers-elements/maps @openlayers-elements/core
+npm add @openlayers-elements/maps @openlayers-elements/core
 ```
 
 Here's the simplest possible OpenStreetMap:

--- a/elements/swisstopo-elements/package.json
+++ b/elements/swisstopo-elements/package.json
@@ -19,7 +19,7 @@
     "@openlayers-elements/core": "^0.3.0",
     "@openlayers-elements/maps": "^0.3.0",
     "lit": "^2.0.0",
-    "ol": "^6.6.0",
+    "ol": "^6.15.0",
     "proj4": "^2.5.0"
   },
   "devDependencies": {

--- a/elements/swisstopo-elements/package.json
+++ b/elements/swisstopo-elements/package.json
@@ -19,7 +19,7 @@
     "@openlayers-elements/core": "^0.3.0",
     "@openlayers-elements/maps": "^0.3.0",
     "lit": "^2.0.0",
-    "ol": "^6.5.0",
+    "ol": "^6.6.0",
     "proj4": "^2.5.0"
   },
   "devDependencies": {

--- a/elements/swisstopo-elements/readme.md
+++ b/elements/swisstopo-elements/readme.md
@@ -9,7 +9,7 @@ See [documentation and demos](https://openlayers-elements.netlify.com).
 To install run
 
 ```
-yarn add @openlayers-elements/swisstopo @openlayers-elements/core
+npm add @openlayers-elements/swisstopo @openlayers-elements/core
 ```
 
 Then add the WMTS layer to your `ol-map` 

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,6 @@
         "eslint-plugin-promise": "^6.0.0",
         "eslint-plugin-standard": "^5.0.0",
         "eslint-plugin-wc": "^1.3.2",
-        "husky": "^8.0.1",
         "lint-staged": "^13.0.3",
         "polymer-cli": "^1.9.11",
         "prettier": "^1.16.4",
@@ -14927,20 +14926,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14.18.0"
-      }
-    },
-    "node_modules/husky": {
-      "version": "8.0.3",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "husky": "lib/bin.js"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -8,15 +8,14 @@
     "elements/*"
   ],
   "scripts": {
-    "prestart": "yarn analyze",
+    "prestart": "npm run analyze",
     "start": "wsrun -p demos -c start",
     "build": "wsrun -x demos -x @openlayers-elements/testing -c build",
     "lint": "eslint --ext .ts,.js elements demos --quiet",
     "test": "wtr",
     "analyze": "polymer analyze --sources elements > demos/analysis.json",
-    "docs": "yarn build; yarn analyze; wsrun -p demos -c build",
-    "release": "changeset publish",
-    "prepare": "husky install"
+    "docs": "npm run build; npm run analyze; wsrun -p demos -c build",
+    "release": "changeset publish"
   },
   "devDependencies": {
     "@changesets/cli": "^2.21.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@rollup/plugin-commonjs": "^17.1.0",
     "@tpluscode/eslint-config": "^0.3.2",
     "@types/mocha": "^9.1.1",
-    "@types/ol": "^6.4.2",
+    "@types/ol": "^6.5.3",
     "@types/sinon": "^9.0.11",
     "@typescript-eslint/eslint-plugin": "^5.32.0",
     "@typescript-eslint/parser": "^5.32.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "eslint-plugin-promise": "^6.0.0",
     "eslint-plugin-standard": "^5.0.0",
     "eslint-plugin-wc": "^1.3.2",
-    "husky": "^8.0.1",
     "lint-staged": "^13.0.3",
     "polymer-cli": "^1.9.11",
     "prettier": "^1.16.4",


### PR DESCRIPTION
- Anticipates merge of https://github.com/openlayers-elements/openlayers-elements/pull/107
- First updates Updates OpenLayers v6.5.0 --> v6.6.0
  - No issues were found resulting from deprecations: https://github.com/openlayers/openlayers/releases/tag/v6.6.0
- Also updates @types/ol to the latest version (prior to replacement by direct incorporation in the `ol` library.
- Then updates OpenLayers v6.6.0 --> v6.15.0, the latest minor increment in v6 (there are no breaking changes between).