### PR TITLE
Update OpenLayers --> v7.5.0

### DIFF
--- a/.changeset/wet-dragons-roll.md
+++ b/.changeset/wet-dragons-roll.md
@@ -1,0 +1,8 @@
+---
+'@openlayers-elements/maps': patch
+'@openlayers-elements/swisstopo': patch
+'@openlayers-elements/core': patch
+'demos': patch
+---
+
+upgrade to openlayers v7, fix typing & tests

--- a/demos/package.json
+++ b/demos/package.json
@@ -19,6 +19,6 @@
     "@openlayers-elements/swisstopo": "^0.3.0",
     "glob": "^10.3.16",
     "lit": "^2.2.8",
-    "ol": "^6.5.0"
+    "ol": "^7.5.0"
   }
 }

--- a/elements/openlayers-core/package.json
+++ b/elements/openlayers-core/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "lit": "^2.0.0",
-    "ol": "^6.6.0"
+    "ol": "^6.15.0"
   },
   "devDependencies": {
     "@open-wc/testing": "^3.1.6",

--- a/elements/openlayers-core/package.json
+++ b/elements/openlayers-core/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "lit": "^2.0.0",
-    "ol": "^6.15.0"
+    "ol": "^7.5.0"
   },
   "devDependencies": {
     "@open-wc/testing": "^3.1.6",

--- a/elements/openlayers-core/package.json
+++ b/elements/openlayers-core/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "lit": "^2.0.0",
-    "ol": "^6.5.0"
+    "ol": "^6.6.0"
   },
   "devDependencies": {
     "@open-wc/testing": "^3.1.6",

--- a/elements/openlayers-elements/ol-marker-icon.ts
+++ b/elements/openlayers-elements/ol-marker-icon.ts
@@ -4,9 +4,8 @@ import Feature from 'ol/Feature.js'
 import Point from 'ol/geom/Point.js'
 import { fromLonLat } from 'ol/proj.js'
 import Icon, { Options } from 'ol/style/Icon.js'
+import type { IconAnchorUnits, IconOrigin } from 'ol/style/Icon.js'
 import Style from 'ol/style/Style.js'
-import IconAnchorUnits from 'ol/style/IconAnchorUnits.js'
-import IconOrigin from 'ol/style/IconOrigin.js'
 import { Size } from 'ol/size.js'
 import OlMap from './ol-map.js'
 
@@ -81,19 +80,19 @@ export default class OlMarkerIcon extends OlFeature {
    * @type {IconAnchorUnits}
    */
   @property({ type: String, attribute: 'anchor-x-units' })
-  public anchorXUnits?: typeof IconAnchorUnits = undefined
+  public anchorXUnits?: IconAnchorUnits = undefined
 
   /**
    * @type {IconAnchorUnits}
    */
   @property({ type: String, attribute: 'anchor-y-units' })
-  public anchorYUnits?: typeof IconAnchorUnits = undefined
+  public anchorYUnits?: IconAnchorUnits = undefined
 
   /**
    * @type {IconOrigin}
    */
   @property({ type: String, attribute: 'anchor-origin' })
-  public anchorOrigin?: typeof IconOrigin = undefined
+  public anchorOrigin?: IconOrigin = undefined
 
   /**
    * @type {string}
@@ -123,7 +122,7 @@ export default class OlMarkerIcon extends OlFeature {
    * @type {IconOrigin}
    */
   @property({ type: Number, attribute: 'offset-origin' })
-  public offsetOrigin: typeof IconOrigin
+  public offsetOrigin: IconOrigin
 
   /**
    * @type {number}

--- a/elements/openlayers-elements/ol-overlay.ts
+++ b/elements/openlayers-elements/ol-overlay.ts
@@ -1,5 +1,6 @@
 import { OlMapPart } from '@openlayers-elements/core/ol-map-part.js'
 import Overlay from 'ol/Overlay.js'
+import type { PanIntoViewOptions } from 'ol/Overlay.js'
 import Map from 'ol/Map.js'
 import { html } from 'lit'
 import { property } from 'lit/decorators.js'
@@ -79,11 +80,7 @@ export default class OlOverlay extends OlMapPart<Overlay> {
 
     const overlayOptions: {
       element: HTMLElement
-      autoPan?: {
-        animation: {
-          duration: number
-        }
-      }
+      autoPan?: PanIntoViewOptions | boolean
     } = {
       element: slotEl,
     }

--- a/elements/openlayers-elements/ol-overlay.ts
+++ b/elements/openlayers-elements/ol-overlay.ts
@@ -85,7 +85,7 @@ export default class OlOverlay extends OlMapPart<Overlay> {
       element: slotEl,
     }
 
-    if (this.autoPan) {
+    if (this.autoPan || this.autoPanAnimationDuration > 0) {
       overlayOptions.autoPan = {
         animation: {
           duration: this.autoPanAnimationDuration,

--- a/elements/openlayers-elements/ol-overlay.ts
+++ b/elements/openlayers-elements/ol-overlay.ts
@@ -66,7 +66,7 @@ export default class OlOverlay extends OlMapPart<Overlay> {
     map.removeOverlay(overlay)
   }
 
-  public async createPart() {
+  public async createPart(): Promise<Overlay> {
     if (!this.id) {
       throw new Error('ol-overlay element must have an id')
     }
@@ -77,19 +77,32 @@ export default class OlOverlay extends OlMapPart<Overlay> {
     const slotEl = document.createElement('slot')
     slotEl.name = slot
 
-    this.__overlay = new Overlay({
+    const overlayOptions: {
+      element: HTMLElement
+      autoPan?: {
+        animation: {
+          duration: number
+        }
+      }
+    } = {
       element: slotEl,
-      autoPan: this.autoPan,
-      autoPanAnimation: {
-        duration: this.autoPanAnimationDuration,
-      } as any,
-    })
+    }
 
-    // hack to get panning correctly calculate overlay dimensions,
+    if (this.autoPan) {
+      overlayOptions.autoPan = {
+        animation: {
+          duration: this.autoPanAnimationDuration,
+        },
+      }
+    }
+
+    this.__overlay = new Overlay(overlayOptions)
+
+    // Hack to get panning to correctly calculate overlay dimensions,
     // which would otherwise be calculated from the <slot> element
-    this.overlay.getElement = () => this
+    this.__overlay.getElement = () => this
 
-    return this.overlay
+    return this.__overlay
   }
 
   /**

--- a/elements/openlayers-elements/package.json
+++ b/elements/openlayers-elements/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@openlayers-elements/core": "^0.3.0",
     "lit": "^2.0.0",
-    "ol": "^6.6.0",
+    "ol": "^6.15.0",
     "resize-observer-polyfill": "^1.5.1"
   },
   "devDependencies": {

--- a/elements/openlayers-elements/package.json
+++ b/elements/openlayers-elements/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@openlayers-elements/core": "^0.3.0",
     "lit": "^2.0.0",
-    "ol": "^6.5.0",
+    "ol": "^6.6.0",
     "resize-observer-polyfill": "^1.5.1"
   },
   "devDependencies": {

--- a/elements/openlayers-elements/package.json
+++ b/elements/openlayers-elements/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@openlayers-elements/core": "^0.3.0",
     "lit": "^2.0.0",
-    "ol": "^6.15.0",
+    "ol": "^7.5.0",
     "resize-observer-polyfill": "^1.5.1"
   },
   "devDependencies": {

--- a/elements/openlayers-elements/test/ol-overlay.test.ts
+++ b/elements/openlayers-elements/test/ol-overlay.test.ts
@@ -15,10 +15,7 @@ describe('ol-overlay', () => {
       const overlay = await element.createPart()
 
       // then
-      const autoPanOptions = overlay.getOptions().autoPan
-      if (typeof autoPanOptions === 'object') {
-        expect(autoPanOptions.animation?.duration).to.equal(0)
-      }
+      expect(overlay.getOptions().autoPan).to.deep.equal({ animation: { duration: 0 } })
     })
 
     it('can be enabled through property', async () => {
@@ -30,10 +27,7 @@ describe('ol-overlay', () => {
       const overlay = await element.createPart()
 
       // then
-      const autoPanOptions = overlay.getOptions().autoPan
-      if (typeof autoPanOptions === 'object') {
-        expect(autoPanOptions.animation?.duration).to.equal(0)
-      }
+      expect(overlay.getOptions().autoPan).to.deep.equal({ animation: { duration: 0 } })
     })
 
     it('is undefined by default', async () => {
@@ -55,10 +49,7 @@ describe('ol-overlay', () => {
       const overlay = await element.createPart()
 
       // then
-      const autoPanOptions = overlay.getOptions().autoPan
-      if (typeof autoPanOptions === 'object') {
-        expect(autoPanOptions.animation?.duration).to.equal(2)
-      }
+      expect(overlay.getOptions().autoPan).to.deep.equal({ animation: { duration: 2 } })
     })
 
     it('only duration is set, auto-enable auto-pan prop', async () => {
@@ -69,10 +60,7 @@ describe('ol-overlay', () => {
       const overlay = await element.createPart()
 
       // then
-      const autoPanOptions = overlay.getOptions().autoPan
-      if (typeof autoPanOptions === 'object') {
-        expect(autoPanOptions.animation?.duration).to.equal(2)
-      }
+      expect(overlay.getOptions().autoPan).to.deep.equal({ animation: { duration: 2 } })
     })
   })
 

--- a/elements/openlayers-elements/test/ol-overlay.test.ts
+++ b/elements/openlayers-elements/test/ol-overlay.test.ts
@@ -15,7 +15,10 @@ describe('ol-overlay', () => {
       const overlay = await element.createPart()
 
       // then
-      expect(overlay.getOptions().autoPan).to.equal(true)
+      const autoPanOptions = overlay.getOptions().autoPan
+      if (typeof autoPanOptions === 'object') {
+        expect(autoPanOptions.animation?.duration).to.equal(0)
+      }
     })
 
     it('can be enabled through property', async () => {
@@ -27,10 +30,13 @@ describe('ol-overlay', () => {
       const overlay = await element.createPart()
 
       // then
-      expect(overlay.getOptions().autoPan).to.equal(true)
+      const autoPanOptions = overlay.getOptions().autoPan
+      if (typeof autoPanOptions === 'object') {
+        expect(autoPanOptions.animation?.duration).to.equal(0)
+      }
     })
 
-    it('is disabled by default', async () => {
+    it('is undefined by default', async () => {
       // given
       const element = (await fixture('<ol-overlay id="foo"></ol-overlay>')) as OlOverlay
 
@@ -38,7 +44,35 @@ describe('ol-overlay', () => {
       const overlay = await element.createPart()
 
       // then
-      expect(overlay.getOptions().autoPan).to.equal(false)
+      expect(overlay.getOptions().autoPan).to.equal(undefined)
+    })
+
+    it('duration can be configured', async () => {
+      // given
+      const element = (await fixture('<ol-overlay id="foo" auto-pan auto-pan-animation-duration="2"></ol-overlay>')) as OlOverlay
+
+      // when
+      const overlay = await element.createPart()
+
+      // then
+      const autoPanOptions = overlay.getOptions().autoPan
+      if (typeof autoPanOptions === 'object') {
+        expect(autoPanOptions.animation?.duration).to.equal(2)
+      }
+    })
+
+    it('only duration is set, auto-enable auto-pan prop', async () => {
+      // given
+      const element = (await fixture('<ol-overlay id="foo" auto-pan-animation-duration="2"></ol-overlay>')) as OlOverlay
+
+      // when
+      const overlay = await element.createPart()
+
+      // then
+      const autoPanOptions = overlay.getOptions().autoPan
+      if (typeof autoPanOptions === 'object') {
+        expect(autoPanOptions.animation?.duration).to.equal(2)
+      }
     })
   })
 

--- a/elements/swisstopo-elements/package.json
+++ b/elements/swisstopo-elements/package.json
@@ -19,7 +19,7 @@
     "@openlayers-elements/core": "^0.3.0",
     "@openlayers-elements/maps": "^0.3.0",
     "lit": "^2.0.0",
-    "ol": "^6.6.0",
+    "ol": "^6.15.0",
     "proj4": "^2.5.0"
   },
   "devDependencies": {

--- a/elements/swisstopo-elements/package.json
+++ b/elements/swisstopo-elements/package.json
@@ -19,7 +19,7 @@
     "@openlayers-elements/core": "^0.3.0",
     "@openlayers-elements/maps": "^0.3.0",
     "lit": "^2.0.0",
-    "ol": "^6.15.0",
+    "ol": "^7.5.0",
     "proj4": "^2.5.0"
   },
   "devDependencies": {

--- a/elements/swisstopo-elements/package.json
+++ b/elements/swisstopo-elements/package.json
@@ -19,7 +19,7 @@
     "@openlayers-elements/core": "^0.3.0",
     "@openlayers-elements/maps": "^0.3.0",
     "lit": "^2.0.0",
-    "ol": "^6.5.0",
+    "ol": "^6.6.0",
     "proj4": "^2.5.0"
   },
   "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "@rollup/plugin-commonjs": "^17.1.0",
         "@tpluscode/eslint-config": "^0.4.5",
         "@types/mocha": "^9.1.1",
-        "@types/ol": "^6.4.2",
         "@types/sinon": "^9.0.11",
         "@typescript-eslint/eslint-plugin": "^7.10.0",
         "@typescript-eslint/parser": "^7.10.0",
@@ -437,7 +436,7 @@
         "@polymer/iron-demo-helpers": "^3.0.2",
         "glob": "^10.3.16",
         "lit": "^2.2.8",
-        "ol": "^6.5.0"
+        "ol": "^7.5.0"
       },
       "devDependencies": {
         "@polymer/polymer": "^3.4.1",
@@ -643,7 +642,7 @@
       "license": "MIT",
       "dependencies": {
         "lit": "^2.0.0",
-        "ol": "^6.5.0"
+        "ol": "^7.5.0"
       },
       "devDependencies": {
         "@open-wc/testing": "^3.1.6",
@@ -683,7 +682,7 @@
       "dependencies": {
         "@openlayers-elements/core": "^0.3.0",
         "lit": "^2.0.0",
-        "ol": "^6.5.0",
+        "ol": "^7.5.0",
         "resize-observer-polyfill": "^1.5.1"
       },
       "devDependencies": {
@@ -724,7 +723,7 @@
         "@openlayers-elements/core": "^0.3.0",
         "@openlayers-elements/maps": "^0.3.0",
         "lit": "^2.0.0",
-        "ol": "^6.5.0",
+        "ol": "^7.5.0",
         "proj4": "^2.5.0"
       },
       "devDependencies": {
@@ -2916,13 +2915,16 @@
     },
     "node_modules/@mapbox/jsonlint-lines-primitives": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
+      "integrity": "sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ==",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/@mapbox/mapbox-gl-style-spec": {
       "version": "13.28.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-style-spec/-/mapbox-gl-style-spec-13.28.0.tgz",
+      "integrity": "sha512-B8xM7Fp1nh5kejfIl4SWeY0gtIeewbuRencqO3cJDrCHZpaPg7uY+V8abuR+esMeuOjRl5cLhVTP40v+1ywxbg==",
       "dependencies": {
         "@mapbox/jsonlint-lines-primitives": "~2.0.2",
         "@mapbox/point-geometry": "^0.1.0",
@@ -2942,11 +2944,13 @@
     },
     "node_modules/@mapbox/point-geometry": {
       "version": "0.1.0",
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz",
+      "integrity": "sha512-6j56HdLTwWGO0fJPlrZtdU/B13q8Uwmo18Ck2GnGgN9PCFyKTZ3UbXeEdRFh18i9XQ92eH2VdtpJHpBD3aripQ=="
     },
     "node_modules/@mapbox/unitbezier": {
       "version": "0.0.0",
-      "license": "BSD-2-Clause"
+      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.0.tgz",
+      "integrity": "sha512-HPnRdYO0WjFjRTSwO3frz1wKaU649OBFPX3Zo/2WZvuRi6zMiRGui8SnPQiQABgqCf8YikDe5t3HViTVw1WUzA=="
     },
     "node_modules/@mdn/browser-compat-data": {
       "version": "4.2.1",
@@ -3603,7 +3607,8 @@
     },
     "node_modules/@petamoriken/float16": {
       "version": "3.8.7",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.8.7.tgz",
+      "integrity": "sha512-/Ri4xDDpe12NT6Ex/DRgHzLlobiQXEW/hmG08w1wj/YU7hLemk97c+zHQFp0iZQ9r7YqgLEXZR2sls4HxBf9NA=="
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -4254,11 +4259,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/arcgis-rest-api": {
-      "version": "10.4.8",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/babel__code-frame": {
       "version": "7.0.6",
       "license": "MIT"
@@ -4541,11 +4541,6 @@
       "license": "MIT",
       "optional": true
     },
-    "node_modules/@types/geojson": {
-      "version": "7946.0.14",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/glob": {
       "version": "7.2.0",
       "dev": true,
@@ -4750,17 +4745,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/ol": {
-      "version": "6.5.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/arcgis-rest-api": "*",
-        "@types/geojson": "*",
-        "@types/rbush": "*",
-        "@types/topojson-specification": "*"
-      }
-    },
     "node_modules/@types/opn": {
       "version": "3.0.28",
       "dev": true,
@@ -4806,11 +4790,6 @@
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
-      "license": "MIT"
-    },
-    "node_modules/@types/rbush": {
-      "version": "3.0.3",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/relateurl": {
@@ -5045,14 +5024,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
-      }
-    },
-    "node_modules/@types/topojson-specification": {
-      "version": "1.0.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/geojson": "*"
       }
     },
     "node_modules/@types/triple-beam": {
@@ -8896,7 +8867,8 @@
     },
     "node_modules/csscolorparser": {
       "version": "1.0.3",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/csscolorparser/-/csscolorparser-1.0.3.tgz",
+      "integrity": "sha512-umPSgYwZkdFoUrH5hIq5kf0wPSXiro51nPw0j2K/c83KflkPSTBGMz6NJvMB+07VlL0y7VPo6QJcDjcgKTTm3w=="
     },
     "node_modules/csv": {
       "version": "5.5.3",
@@ -12156,35 +12128,38 @@
       }
     },
     "node_modules/geotiff": {
-      "version": "2.0.4",
-      "license": "MIT",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-2.1.3.tgz",
+      "integrity": "sha512-PT6uoF5a1+kbC3tHmZSUsLHBp2QJlHasxxxxPW47QIY1VBKpFB+FcDvX+MxER6UzgLQZ0xDzJ9s48B9JbOCTqA==",
       "dependencies": {
         "@petamoriken/float16": "^3.4.7",
         "lerc": "^3.0.0",
-        "lru-cache": "^6.0.0",
         "pako": "^2.0.4",
         "parse-headers": "^2.0.2",
+        "quick-lru": "^6.1.1",
         "web-worker": "^1.2.0",
-        "xml-utils": "^1.0.2"
+        "xml-utils": "^1.0.2",
+        "zstddec": "^0.1.0"
       },
       "engines": {
-        "browsers": "defaults",
         "node": ">=10.19"
-      }
-    },
-    "node_modules/geotiff/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/geotiff/node_modules/pako": {
       "version": "2.1.0",
-      "license": "(MIT AND Zlib)"
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
+    },
+    "node_modules/geotiff/node_modules/quick-lru": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-6.1.2.tgz",
+      "integrity": "sha512-AAFUA5O1d83pIHEhJwWCq/RQcRukCkn/NSm2QsTEMle5f2hP0ChI2+3Xb051PZCkLryI/Ir1MVKviT2FIloaTQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
@@ -14591,7 +14566,8 @@
     },
     "node_modules/json-stringify-pretty-compact": {
       "version": "2.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-2.0.0.tgz",
+      "integrity": "sha512-WRitRfs6BGq4q8gTgOy4ek7iPFXjbra0H3PmDLKm2xnZ+Gh1HUhiKGgCZkSPNULlP7mvfu6FV/mOLhCarspADQ=="
     },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
@@ -14963,7 +14939,8 @@
     },
     "node_modules/lerc": {
       "version": "3.0.0",
-      "license": "Apache-2.0"
+      "resolved": "https://registry.npmjs.org/lerc/-/lerc-3.0.0.tgz",
+      "integrity": "sha512-Rm4J/WaHhRa93nCN2mwWDZFoRVF18G1f47C+kvQWyHGEZxFpTUi73p7lMVSAndyxGt6lJ2/CFbOcf9ra5p8aww=="
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -15891,7 +15868,8 @@
     },
     "node_modules/mapbox-to-css-font": {
       "version": "2.4.4",
-      "license": "BSD-2-Clause"
+      "resolved": "https://registry.npmjs.org/mapbox-to-css-font/-/mapbox-to-css-font-2.4.4.tgz",
+      "integrity": "sha512-X1dtuTuH2D1MRMuductMZCLV/fy9EoIgqW/lmu8vQSAhEatx/tdFebkYT3TVhdTwqFDHbLEgQBD3IKA4KI7aoQ=="
     },
     "node_modules/marked": {
       "version": "0.3.19",
@@ -16915,11 +16893,13 @@
       "license": "MIT"
     },
     "node_modules/ol": {
-      "version": "6.15.1",
-      "license": "BSD-2-Clause",
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/ol/-/ol-7.5.2.tgz",
+      "integrity": "sha512-HJbb3CxXrksM6ct367LsP3N+uh+iBBMdP3DeGGipdV9YAYTP0vTJzqGnoqQ6C2IW4qf8krw9yuyQbc9fjOIaOQ==",
       "dependencies": {
-        "geotiff": "2.0.4",
-        "ol-mapbox-style": "^8.0.5",
+        "earcut": "^2.2.3",
+        "geotiff": "^2.0.7",
+        "ol-mapbox-style": "^10.1.0",
         "pbf": "3.2.1",
         "rbush": "^3.0.1"
       },
@@ -16929,11 +16909,13 @@
       }
     },
     "node_modules/ol-mapbox-style": {
-      "version": "8.2.1",
-      "license": "BSD-2-Clause",
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-10.7.0.tgz",
+      "integrity": "sha512-S/UdYBuOjrotcR95Iq9AejGYbifKeZE85D9VtH11ryJLQPTZXZSW1J5bIXcr4AlAH6tyjPPHTK34AdkwB32Myw==",
       "dependencies": {
         "@mapbox/mapbox-gl-style-spec": "^13.23.1",
-        "mapbox-to-css-font": "^2.4.1"
+        "mapbox-to-css-font": "^2.4.1",
+        "ol": "^7.3.0"
       }
     },
     "node_modules/on-finished": {
@@ -17244,7 +17226,8 @@
     },
     "node_modules/parse-headers": {
       "version": "2.0.5",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.5.tgz",
+      "integrity": "sha512-ft3iAoLOB/MlwbNXgzy43SWGP6sQki2jQvAyBg/zDFAgr9bfNWZIUj42Kw2eJIl8kEi4PbgE6U1Zau/HwI75HA=="
     },
     "node_modules/parse-json": {
       "version": "2.2.0",
@@ -20208,7 +20191,8 @@
     },
     "node_modules/rw": {
       "version": "1.3.3",
-      "license": "BSD-3-Clause"
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="
     },
     "node_modules/rx": {
       "version": "4.1.0",
@@ -21216,12 +21200,16 @@
     },
     "node_modules/sort-asc": {
       "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/sort-asc/-/sort-asc-0.1.0.tgz",
+      "integrity": "sha512-jBgdDd+rQ+HkZF2/OHCmace5dvpos/aWQpcxuyRs9QUbPRnkEJmYVo81PIGpjIdpOcsnJ4rGjStfDHsbn+UVyw==",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/sort-desc": {
       "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/sort-desc/-/sort-desc-0.1.1.tgz",
+      "integrity": "sha512-jfZacW5SKOP97BF5rX5kQfJmRVZP5/adDUTY8fCSPvNcXDVpUEe2pr/iKGlcyZzchRJZrswnp68fgk3qBXgkJw==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -21250,6 +21238,8 @@
     },
     "node_modules/sort-object": {
       "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/sort-object/-/sort-object-0.3.2.tgz",
+      "integrity": "sha512-aAQiEdqFTTdsvUFxXm3umdo04J7MRljoVGbBlkH7BgNsMvVNAJyGj7C/wV1A8wHWAJj/YikeZbfuCKqhggNWGA==",
       "dependencies": {
         "sort-asc": "^0.1.0",
         "sort-desc": "^0.1.1"
@@ -23643,7 +23633,8 @@
     },
     "node_modules/web-worker": {
       "version": "1.3.0",
-      "license": "Apache-2.0"
+      "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.3.0.tgz",
+      "integrity": "sha512-BSR9wyRsy/KOValMgd5kMyr3JzpdeoR9KVId8u5GVlTTAtNChlsE4yTxeY7zMdNSyOmoKBv8NH2qeRY9Tg+IaA=="
     },
     "node_modules/webidl-conversions": {
       "version": "4.0.2",
@@ -24064,7 +24055,8 @@
     },
     "node_modules/xml-utils": {
       "version": "1.8.0",
-      "license": "CC0-1.0"
+      "resolved": "https://registry.npmjs.org/xml-utils/-/xml-utils-1.8.0.tgz",
+      "integrity": "sha512-1TY5yLw8DApowZAUsWCniNr8HH6Ebt6O7UQvmIwziGKwUNsQx6e+4NkfOvCfnqmYIcPjCeoI6dh1JenPJ9a1hQ=="
     },
     "node_modules/xmlbuilder": {
       "version": "8.2.2",
@@ -24106,6 +24098,7 @@
     },
     "node_modules/yallist": {
       "version": "4.0.0",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/yaml": {
@@ -25153,6 +25146,11 @@
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
+    },
+    "node_modules/zstddec": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/zstddec/-/zstddec-0.1.0.tgz",
+      "integrity": "sha512-w2NTI8+3l3eeltKAdK8QpiLo/flRAr2p8AGeakfMZOXBxOg9HIu4LVDxBi81sYgVhFhdJjv1OrB5ssI8uFPoLg=="
     },
     "test": {
       "name": "@openlayers-elements/testing",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@rollup/plugin-commonjs": "^17.1.0",
     "@tpluscode/eslint-config": "^0.4.5",
     "@types/mocha": "^9.1.1",
-    "@types/ol": "^6.4.2",
+    "@types/ol": "^6.5.3",
     "@types/sinon": "^9.0.11",
     "@typescript-eslint/eslint-plugin": "^7.10.0",
     "@typescript-eslint/parser": "^7.10.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "@rollup/plugin-commonjs": "^17.1.0",
     "@tpluscode/eslint-config": "^0.4.5",
     "@types/mocha": "^9.1.1",
-    "@types/ol": "^6.5.3",
     "@types/sinon": "^9.0.11",
     "@typescript-eslint/eslint-plugin": "^7.10.0",
     "@typescript-eslint/parser": "^7.10.0",


### PR DESCRIPTION
- ~~Anticipates the merge of https://github.com/openlayers-elements/openlayers-elements/pull/107~~
- Updates to latest OpenLayers v7 version.
- Minor fixes:
  - Update some of the typing for the ol-marker-icon component.
  - Replace the deprecated `autoPanAnimation` from Overlay, in favour of using the `animation` property of `Overlay`: `Overlay({animation: true})`.
  - Fixes tests for ol-overlay.
