### PR TITLE
Fix netlify website deployment

### DIFF
--- a/.github/workflows/netlify.yaml
+++ b/.github/workflows/netlify.yaml
@@ -16,7 +16,7 @@ jobs:
       - uses: Wohlstand/branch-name@v1.0.2-wohl
 
       - name: Publish preview
-        uses: jsmrcaga/action-netlify-deploy@v1.7.2
+        uses: jsmrcaga/action-netlify-deploy@v2.2.0
         if: env.NETLIFY_AUTH_TOKEN
         with:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
@@ -26,10 +26,9 @@ jobs:
           build_directory: demos/dist
           deploy_alias: ${{ env.BRANCH_NAME }}
           NETLIFY_DEPLOY_TO_PROD: ${{ env.BRANCH_NAME == 'master' }}
-          node_version: 20
 
       - name: Status check
-        uses: Sibz/github-status-action@v1.1.1
+        uses: guibranco/github-status-action-v2@v1.1.13
         if: env.NETLIFY_AUTH_TOKEN
         with:
           authToken: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Issue

- The netlify deployment workflow was failing: https://github.com/openlayers-elements/openlayers-elements/actions/runs/9099172819/job/25011110579
- This is due to conflicting versions of node: `node: /lib/x86_64-linux-gnu/libm.so.6: version GLIBC_2.27' not found (required by node)`.
- The culprit was the `jsmrcaga/action-netlify-deploy` action, which at v1.7.2 build a docker image prior to running. This image was based of an old Ubuntu version and hence included an old version of node.

### Solution

- Updating the workflow to v2.2.0 should solve this issue. I removed the deprecated `node_version: 20` argument (this is specified in `actions/setup-node@v4` above.
- I also updated `Sibz/github-status-action`, which is no longer maintained, to the suggested fork `guibranco/github-status-action-v2`.

### Notes

- I didn't have time to set up **act** and test this workflow locally, so hopefully it runs fine 🤞 