### PR TITLE
ci: remove browserstack

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,9 +24,6 @@ jobs:
           node-version: 20
       - run: npm ci
       - run: npm run test
-        env:
-          BROWSER_STACK_USERNAME: ${{ secrets.BROWSER_STACK_USERNAME }}
-          BROWSER_STACK_ACCESS_KEY: ${{ secrets.BROWSER_STACK_ACCESS_KEY }}
       - name: Codecov
         uses: codecov/codecov-action@v4
         with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,6 @@
         "@web/dev-server-esbuild": "^0.2.16",
         "@web/dev-server-rollup": "^0.3.15",
         "@web/test-runner": "^0.13.27",
-        "@web/test-runner-browserstack": "^0.4.4",
         "eslint": "^8",
         "eslint-import-resolver-typescript": "^3.6.1",
         "husky": "^9",
@@ -5836,21 +5835,6 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/@web/test-runner-browserstack": {
-      "version": "0.4.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@web/test-runner-selenium": "^0.5.3",
-        "browserstack-local": "^1.4.8",
-        "ip": "^1.1.5",
-        "nanoid": "^3.1.25",
-        "selenium-webdriver": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "node_modules/@web/test-runner-chrome": {
       "version": "0.10.7",
       "dev": true,
@@ -5967,18 +5951,6 @@
       "version": "8.2.3",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@web/test-runner-selenium": {
-      "version": "0.5.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@web/test-runner-core": "^0.10.20",
-        "selenium-webdriver": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
     },
     "node_modules/@web/test-runner/node_modules/array-back": {
       "version": "4.0.2",
@@ -7592,18 +7564,6 @@
       "optional": true,
       "dependencies": {
         "https-proxy-agent": "^2.2.1"
-      }
-    },
-    "node_modules/browserstack-local": {
-      "version": "1.5.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^6.0.2",
-        "https-proxy-agent": "^5.0.1",
-        "is-running": "^2.1.0",
-        "ps-tree": "=1.2.0",
-        "temp-fs": "^0.9.9"
       }
     },
     "node_modules/browserstack/node_modules/agent-base": {
@@ -9576,11 +9536,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/duplexer": {
-      "version": "0.1.2",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/duplexer2": {
       "version": "0.1.4",
       "dev": true,
@@ -11120,31 +11075,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/event-stream": {
-      "version": "3.3.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "duplexer": "~0.1.1",
-        "from": "~0",
-        "map-stream": "~0.1.0",
-        "pause-stream": "0.0.11",
-        "split": "0.3",
-        "stream-combiner": "~0.0.4",
-        "through": "~2.3.1"
-      }
-    },
-    "node_modules/event-stream/node_modules/split": {
-      "version": "0.3.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "through": "2"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/eventemitter3": {
       "version": "5.0.1",
       "dev": true,
@@ -12210,11 +12140,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/from": {
-      "version": "0.1.7",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/fs-constants": {
       "version": "1.0.0",
@@ -13550,11 +13475,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/immediate": {
-      "version": "3.0.6",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "dev": true,
@@ -14336,11 +14256,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-running": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "BSD"
-    },
     "node_modules/is-scoped": {
       "version": "1.0.0",
       "dev": true,
@@ -14863,17 +14778,6 @@
         "node": ">=4.0"
       }
     },
-    "node_modules/jszip": {
-      "version": "3.10.1",
-      "dev": true,
-      "license": "(MIT OR GPL-3.0-or-later)",
-      "dependencies": {
-        "lie": "~3.3.0",
-        "pako": "~1.0.2",
-        "readable-stream": "~2.3.6",
-        "setimmediate": "^1.0.5"
-      }
-    },
     "node_modules/just-extend": {
       "version": "4.2.1",
       "dev": true,
@@ -15171,14 +15075,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/lie": {
-      "version": "3.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "immediate": "~3.0.5"
       }
     },
     "node_modules/lighthouse-logger": {
@@ -16067,10 +15963,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/map-stream": {
-      "version": "0.1.0",
-      "dev": true
     },
     "node_modules/map-visit": {
       "version": "1.0.0",
@@ -17392,11 +17284,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/pako": {
-      "version": "1.0.11",
-      "dev": true,
-      "license": "(MIT AND Zlib)"
-    },
     "node_modules/param-case": {
       "version": "2.1.1",
       "dev": true,
@@ -17597,17 +17484,6 @@
       "peer": true,
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/pause-stream": {
-      "version": "0.0.11",
-      "dev": true,
-      "license": [
-        "MIT",
-        "Apache2"
-      ],
-      "dependencies": {
-        "through": "~2.3"
       }
     },
     "node_modules/pbf": {
@@ -19388,20 +19264,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/ps-tree": {
-      "version": "1.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "event-stream": "=3.3.4"
-      },
-      "bin": {
-        "ps-tree": "bin/ps-tree.js"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/pseudomap": {
       "version": "1.0.2",
       "dev": true,
@@ -20722,47 +20584,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/selenium-webdriver": {
-      "version": "4.20.0",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "jszip": "^3.10.1",
-        "tmp": "^0.2.3",
-        "ws": ">=8.16.0"
-      },
-      "engines": {
-        "node": ">= 14.20.0"
-      }
-    },
-    "node_modules/selenium-webdriver/node_modules/tmp": {
-      "version": "0.2.3",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
-    "node_modules/selenium-webdriver/node_modules/ws": {
-      "version": "8.17.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/semver": {
       "version": "7.6.2",
       "license": "ISC",
@@ -21037,11 +20858,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/setimmediate": {
-      "version": "1.0.5",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -21965,14 +21781,6 @@
         "emitter-component": "^1.1.1"
       }
     },
-    "node_modules/stream-combiner": {
-      "version": "0.0.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "duplexer": "~0.1.1"
-      }
-    },
     "node_modules/stream-read-all": {
       "version": "3.0.1",
       "dev": true,
@@ -22424,28 +22232,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/temp-fs": {
-      "version": "0.9.9",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "rimraf": "~2.5.2"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/temp-fs/node_modules/rimraf": {
-      "version": "2.5.4",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.0.5"
-      },
-      "bin": {
-        "rimraf": "bin.js"
       }
     },
     "node_modules/temp/node_modules/rimraf": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "@web/dev-server-esbuild": "^0.2.16",
     "@web/dev-server-rollup": "^0.3.15",
     "@web/test-runner": "^0.13.27",
-    "@web/test-runner-browserstack": "^0.4.4",
     "eslint": "^8",
     "eslint-import-resolver-typescript": "^3.6.1",
     "husky": "^9",

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -2,54 +2,6 @@
 import { esbuildPlugin } from '@web/dev-server-esbuild'
 import { fromRollup } from '@web/dev-server-rollup'
 import commonjs from '@rollup/plugin-commonjs'
-import { browserstackLauncher } from '@web/test-runner-browserstack'
-
-let bsConfig = {}
-if (process.env.BROWSER_STACK_USERNAME && process.env.BROWSER_STACK_ACCESS_KEY) {
-  const sharedCapabilities = {
-    'browserstack.user': process.env.BROWSER_STACK_USERNAME,
-    'browserstack.key': process.env.BROWSER_STACK_ACCESS_KEY,
-
-    project: '@openlayers-elements/maps',
-    name: 'Tests',
-    build: `build ${process.env.GITHUB_RUN_NUMBER || 'unknown'}`,
-  }
-
-  bsConfig = {
-    concurrentBrowsers: 2,
-    browsers: [
-      // create a browser launcher per browser you want to test
-      // you can get the browser capabilities from the browserstack website
-      browserstackLauncher({
-        capabilities: {
-          ...sharedCapabilities,
-          browserName: 'Chrome',
-          os: 'Windows',
-          os_version: '10',
-        },
-      }),
-
-      browserstackLauncher({
-        capabilities: {
-          ...sharedCapabilities,
-          browserName: 'Safari',
-          browser_version: '14.1',
-          os: 'OS X',
-          os_version: 'Big Sur',
-        },
-      }),
-
-      browserstackLauncher({
-        capabilities: {
-          ...sharedCapabilities,
-          browserName: 'Edge',
-          os: 'Windows',
-          os_version: '10',
-        },
-      }),
-    ],
-  }
-}
 
 export default {
   files: 'elements/**/*.test.ts',
@@ -66,5 +18,4 @@ export default {
       ],
     }),
   ],
-  ...bsConfig,
 }


### PR DESCRIPTION
I don't think the benefits of running browserstack justifies the effort. All moderns browsers support the necessary web specs and if needed, we can run headless on various runner platform provided by GitHub