### PR TITLE
Add contrib config for tests via docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,18 @@ You may also start a watch process to update the generated custom elements manif
 ```sh
 npm -w storybook run custom-elements-manifest:watch
 ```
+
+## Running tests
+
+If the Chrome binary / driver is installed in your PATH, simply run:
+
+```sh
+npm run test
+```
+
+To run with a container-based Chrome driver, instead run:
+
+```sh
+docker compose -f contrib/docker/docker-compose.tests.yml \
+  run --rm test
+```

--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -12,7 +12,7 @@ COPY --chown=pwuser elements/openlayers-elements/package.json .
 WORKDIR /app/elements/swisstopo-elements
 COPY --chown=pwuser elements/swisstopo-elements/package.json .
 WORKDIR /app
-COPY --chown=pwuser package.json package-lock.json .
+COPY --chown=pwuser package.json package-lock.json ./
 # Workaround for MacOS issues
 VOLUME /app/node_modules
 # Clean install node_modules for root package + all workspaces

--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -13,8 +13,6 @@ WORKDIR /app/elements/swisstopo-elements
 COPY --chown=pwuser elements/swisstopo-elements/package.json .
 WORKDIR /app
 COPY --chown=pwuser package.json package-lock.json ./
-# Workaround for MacOS issues
-VOLUME /app/node_modules
 # Clean install node_modules for root package + all workspaces
 RUN npm ci
 COPY --chown=pwuser . .

--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -13,7 +13,9 @@ WORKDIR /app/elements/swisstopo-elements
 COPY --chown=pwuser elements/swisstopo-elements/package.json .
 WORKDIR /app
 COPY --chown=pwuser package.json package-lock.json .
-# CLean install node_modules for root package + all workspaces
+# Workaround for MacOS issues
+VOLUME /app/node_modules
+# Clean install node_modules for root package + all workspaces
 RUN npm ci
 COPY --chown=pwuser . .
 

--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -1,0 +1,20 @@
+FROM mcr.microsoft.com/playwright:v1.44.1
+# The chromium version must be updated with playwright container upgrade
+ENV CHROME_PATH /ms-playwright/chromium-1117/chrome-linux/chrome
+
+# Required to run as pwuser chromium sandbox security
+USER pwuser
+# Add package.json for each workspace
+WORKDIR /app/elements/openlayers-core
+COPY --chown=pwuser elements/openlayers-core/package.json .
+WORKDIR /app/elements/openlayers-elements
+COPY --chown=pwuser elements/openlayers-elements/package.json .
+WORKDIR /app/elements/swisstopo-elements
+COPY --chown=pwuser elements/swisstopo-elements/package.json .
+WORKDIR /app
+COPY --chown=pwuser package.json package-lock.json .
+# CLean install node_modules for root package + all workspaces
+RUN npm ci
+COPY --chown=pwuser . .
+
+CMD npm run test

--- a/contrib/docker/Dockerfile.dockerignore
+++ b/contrib/docker/Dockerfile.dockerignore
@@ -1,0 +1,8 @@
+# Ignore everything
+**/**/node_modules
+.changeset
+.husky
+assets
+contrib
+coverage
+test

--- a/contrib/docker/docker-compose.tests.yml
+++ b/contrib/docker/docker-compose.tests.yml
@@ -1,17 +1,18 @@
 services:
   test:
-    image: mcr.microsoft.com/playwright:v1.44.1
-    working_dir: /app
-    environment:
-      CHROME_PATH: /ms-playwright/chromium-1117/chrome-linux/chrome
+    image: ghcr.io/openlayers-elements/openlayers-elements:ci
+    build:
+      context: ../../
+      dockerfile: contrib/docker/Dockerfile
     volumes:
-      - ../../:/app/
+      # Required to not mount node_module dirs
+      - /app/elements/openlayers-core/node_modules
+      - /app/elements/openlayers-elements/node_modules
+      - /app/elements/swisstopo-elements/node_modules
+      - ../../elements:/app/elements
     # To prevent out of memory errors
     ipc: host
     # Required to run chromium sandbox
     cap_add:
       - SYS_ADMIN
-    # Required to run chromium sandbox
-    user: pwuser
-    command: npm run test
     restart: "never"

--- a/contrib/docker/docker-compose.tests.yml
+++ b/contrib/docker/docker-compose.tests.yml
@@ -1,0 +1,17 @@
+services:
+  test:
+    image: mcr.microsoft.com/playwright:v1.44.1
+    working_dir: /app
+    environment:
+      CHROME_PATH: /ms-playwright/chromium-1117/chrome-linux/chrome
+    volumes:
+      - ../../:/app/
+    # To prevent out of memory errors
+    ipc: host
+    # Required to run chromium sandbox
+    cap_add:
+      - SYS_ADMIN
+    # Required to run chromium sandbox
+    user: pwuser
+    command: npm run test
+    restart: "never"


### PR DESCRIPTION
- I added a small docker-compose config file to run the tests via a container, including bundled Chrome, Webkit & Firefox browsers from the official Playwright image.
- Using this it's possible to easily test using all three browsers, even if not installed on the dev's machine. We could also use Playwright in the future if desirable.
- Of course we could just say: 'make sure you install the Chrome binary prior to running tests'. But it's also nice to have options. I wanted to check if anyone else finds this useful & if it belongs in a `contrib` directory.