### PR TITLE
Update ol-map docs to include info about parent element height

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 While there are many great framework-specific OpenLayers wrappers, the goal of this
 project is to wrap OpenLayers in W3C Web Components, which are a web standard
-supported by allow browsers currently and into the future.
+supported by all browsers currently and into the future.
 
 This is a monorepo which contains:
 

--- a/elements/openlayers-core/ol-map.ts
+++ b/elements/openlayers-core/ol-map.ts
@@ -21,19 +21,29 @@ import { forwardEvents } from './lib/events.js'
  *
  * ### Setting the map container height
  *
- * It is expected that the map element will be wrapped in another element on your page.
- * By default the map element has 100% height, meaning it will fill the parent element.
+ * By default ol-map has `flex: 1` styling, so it will expand to fill the parent element.
+ * To achieve this set the `display: flex` CSS property on your parent element.
  *
- * In order to ensure the map fills the parent container, using `flex` may be required.
- * An example CSS file:
+ * ```html
+ * <div id="parent-element">
+ *   <ol-map>
+ *     ...
+ *   </ol-map>
+ * </div>
+ * ```
  *
  * ```css
  * #parent-element {
  *   display: flex;
  *   height: 400px;
  * }
+ * ```
+ *
+ * Alternatively, the ol-map class styling can be overriden:
+ *
+ * ```css
  * ol-map {
- *   flex: 1;
+ *   height: 80vh;
  * }
  * ```
  *

--- a/elements/openlayers-core/ol-map.ts
+++ b/elements/openlayers-core/ol-map.ts
@@ -19,6 +19,24 @@ import { forwardEvents } from './lib/events.js'
  * </ol-map>
  * ```
  *
+ * ### Setting the map container height
+ *
+ * It is expected that the map element will be wrapped in another element on your page.
+ * By default the map element has 100% height, meaning it will fill the parent element.
+ *
+ * In order to ensure the map fills the parent container, using `flex` may be required.
+ * An example CSS file:
+ *
+ * ```css
+ * #parent-element {
+ *   display: flex;
+ *   height: 400px;
+ * }
+ * ol-map {
+ *   flex: 1;
+ * }
+ * ```
+ *
  * ### Controlling zoom level
  *
  * The simpler way to set zoom is to set the `zoom` property. Alternatively, `resolution` can be used instead.


### PR DESCRIPTION
## Related Issue

As mentioned in #126

## Describe this PR

- Fixed a typo in the readme.
- Update ol-map docstring with info about flex height of parent container.

## Checklist before requesting a review

- [x] Information about the PR, including descriptive commits and link to issue
- [x] All tests are passing
  - Run tests locally with: `npm run test`, or view via the CI workflow.
- [x] Includes a changeset, if required.
  - Run `npx changeset`.
