### PR TITLE
Fix storybook styled-map css for display

### DIFF
--- a/storybook/.storybook/preview-head.html
+++ b/storybook/.storybook/preview-head.html
@@ -11,4 +11,8 @@
   ol-map {
     flex: 1;
   }
+
+  styled-map {
+    flex: 1;
+  }
 </style>


### PR DESCRIPTION
- The `ol-layer-geojson` story was not displaying a map.
- Small fix to add `flex` to `styled-map` css, the same as `ol-map`.

Before:

![Screenshot 2024-06-20 122514](https://github.com/openlayers-elements/openlayers-elements/assets/78538841/8664e8b0-6360-42e9-98b7-fe0b5168c95a)

After:

![Screenshot 2024-06-20 122532](https://github.com/openlayers-elements/openlayers-elements/assets/78538841/bdd75c3c-3def-4c3d-ada6-47820e5d0fb4)

