### PR TITLE
Add 3d map perspective via ol-map pitch param

### DIFF
--- a/.changeset/great-pianos-sleep.md
+++ b/.changeset/great-pianos-sleep.md
@@ -1,7 +1,7 @@
 ---
-'@openlayers-elements/maps': patch
-'@openlayers-elements/swisstopo': patch
-'@openlayers-elements/core': patch
+'@openlayers-elements/maps': minor
+'@openlayers-elements/swisstopo': minor
+'@openlayers-elements/core': minor
 'demos': patch
 ---
 

--- a/.changeset/great-pianos-sleep.md
+++ b/.changeset/great-pianos-sleep.md
@@ -1,0 +1,8 @@
+---
+'@openlayers-elements/maps': patch
+'@openlayers-elements/swisstopo': patch
+'@openlayers-elements/core': patch
+'demos': patch
+---
+
+upgrade to openlayers v9, use ol flat styling syntax

--- a/elements/openlayers-core/lib/3dMatrix.ts
+++ b/elements/openlayers-core/lib/3dMatrix.ts
@@ -1,0 +1,236 @@
+/* See
+https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API/Matrix_math_for_the_web
+https://evanw.github.io/lightgl.js/docs/matrix.html
+https://github.com/jlmakes/rematrix
+https://jsfiddle.net/2znLxda2/
+*/
+/** Matrix3D; a set of functions to handle matrix3D
+ */
+
+/** Get transform matrix3D of an element
+ * @param {Element} ele
+ * @return {Array<Array<number>>}
+ */
+function getTransform(ele: Element): number[][] {
+  const style = window.getComputedStyle(ele, null)
+
+  const tr = style.getPropertyValue('-webkit-transform') ||
+    style.getPropertyValue('-moz-transform') ||
+    style.getPropertyValue('-ms-transform') ||
+    style.getPropertyValue('-o-transform') ||
+    style.getPropertyValue('transform')
+
+  const values = tr.split('(')[1].split(')')[0].split(',')
+
+  const mx: number[][] = [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]]
+  let i: number,
+    j: number
+  if (values.length === 16) {
+    for (i = 0; i < 4; i += 1) {
+      for (j = 0; j < 4; j += 1) {
+        mx[j][i] = +values[i * 4 + j]
+      }
+    }
+  } else {
+    for (i = 0; i < 3; i += 1) {
+      for (j = 0; j < 2; j += 1) {
+        mx[j][i] = +values[i * 2 + j]
+      }
+    }
+  }
+
+  return mx
+}
+
+/** Get transform matrix3D of an element
+ * @param {Element} ele
+ * @return {Array<number>}
+ */
+function getTransformOrigin(ele: Element): number[] {
+  const style = window.getComputedStyle(ele, null)
+
+  const tr = style.getPropertyValue('-webkit-transform-origin') ||
+    style.getPropertyValue('-moz-transform-origin') ||
+    style.getPropertyValue('-ms-transform-origin') ||
+    style.getPropertyValue('-o-transform-origin') ||
+    style.getPropertyValue('transform-origin')
+
+  const values = tr.split(' ')
+
+  const mx: number[] = [0, 0, 0, 1]
+  for (let i = 0; i < values.length; i += 1) {
+    mx[i] = parseInt(values[i], 10)
+  }
+  return mx
+}
+
+/** Compute translate matrix
+ * @param {number} x
+ * @param {number} y
+ * @param {number} z
+ * @return {Array<Array<number>>}
+ */
+function translateMatrix(x: number, y: number, z: number): number[][] {
+  return [
+    [1, 0, 0, x],
+    [0, 1, 0, y],
+    [0, 0, 1, z],
+    [0, 0, 0, 1],
+  ]
+}
+
+/** Identity matrix
+ * @return {Array<Array<number>>}
+ */
+function identity(): number[][] {
+  return [
+    [1, 0, 0, 0],
+    [0, 1, 0, 0],
+    [0, 0, 1, 0],
+    [0, 0, 0, 1],
+  ]
+}
+
+/** Round matrix
+ * @param {Array<Array<number>>} mx
+ * @param {number} round Rounding value, default 1E-10
+ */
+function roundTo(mx: number[][], round: number = 1E-10): number[][] {
+  const m: number[][] = [[], [], [], []]
+  for (let i = 0; i < 4; i += 1) {
+    for (let j = 0; j < 4; j += 1) {
+      m[i][j] = Math.round(mx[i][j] / round) * round
+    }
+  }
+  return m
+}
+
+/** Multiply matrix3D
+ * @param {Array<Array<number>>} mx1
+ * @param {Array<Array<number>>} mx2
+ * @return {Array<Array<number>>}
+ */
+function multiply(mx1: number[][], mx2: number[][]): number[][] {
+  const mx: number[][] = [[], [], [], []]
+
+  for (let i = 0; i < 4; i += 1) {
+    for (let j = 0; j < 4; j += 1) {
+      let sum = 0
+      for (let k = 0; k < 4; k += 1) {
+        sum += (mx1[k][i] * mx2[j][k])
+      }
+      mx[j][i] = sum
+    }
+  }
+
+  return mx
+}
+
+/** Compute the full transform that is applied to the transformed parent: -origin o tx o origin
+ * @param {Array<Array<number>>} tx transform matrix
+ * @param {Array<Array<number>>} origin transform origin
+ * @return {Array<Array<number>>}
+ */
+function computeTransformMatrix(tx: number[][], origin: number[]): number[][] {
+  const preTx = translateMatrix(-origin[0], -origin[1], -origin[2])
+  const postTx = translateMatrix(origin[0], origin[1], origin[2])
+
+  const temp1 = multiply(preTx, tx)
+
+  return multiply(temp1, postTx)
+}
+
+/** Apply transform to a coordinate
+ * @param {Array<Array<number>>} tx
+ * @param {ol.pixel} px
+ */
+function transformVertex(tx: number[][], px: [number, number]): number[] {
+  const vert: number[] = [px[0], px[1], 0, 1]
+  const mx: number[] = []
+
+  for (let i = 0; i < 4; i += 1) {
+    mx[i] = 0
+    for (let j = 0; j < 4; j += 1) {
+      mx[i] += +tx[i][j] * vert[j]
+    }
+  }
+
+  return mx
+}
+
+/** Perform the homogeneous divide to apply perspective to the points (divide x,y,z by the w component).
+ * @param {Array<number>} vert
+ * @return {Array<number>}
+ */
+function projectVertex(vert: number[]): number[] {
+  const out: number[] = []
+
+  for (let i = 0; i < 4; i += 1) {
+    out[i] = vert[i] / vert[3]
+  }
+
+  return out
+}
+
+/** Inverse a matrix3D
+ * @return {Array<Array<number>>} m matrix to transform
+ * @return {Array<Array<number>>}
+ */
+function inverse(m: number[][]): number[][] {
+  const s0 = m[0][0] * m[1][1] - m[1][0] * m[0][1]
+  const s1 = m[0][0] * m[1][2] - m[1][0] * m[0][2]
+  const s2 = m[0][0] * m[1][3] - m[1][0] * m[0][3]
+  const s3 = m[0][1] * m[1][2] - m[1][1] * m[0][2]
+  const s4 = m[0][1] * m[1][3] - m[1][1] * m[0][3]
+  const s5 = m[0][2] * m[1][3] - m[1][2] * m[0][3]
+
+  const c5 = m[2][2] * m[3][3] - m[3][2] * m[2][3]
+  const c4 = m[2][1] * m[3][3] - m[3][1] * m[2][3]
+  const c3 = m[2][1] * m[3][2] - m[3][1] * m[2][2]
+  const c2 = m[2][0] * m[3][3] - m[3][0] * m[2][3]
+  const c1 = m[2][0] * m[3][2] - m[3][0] * m[2][2]
+  const c0 = m[2][0] * m[3][1] - m[3][0] * m[2][1]
+
+  const determinant = 1 / (s0 * c5 - s1 * c4 + s2 * c3 + s3 * c2 - s4 * c1 + s5 * c0)
+
+  if (Number.isNaN(determinant) || determinant === Infinity) {
+    throw new Error('Inverse determinant attempted to divide by zero.')
+  }
+
+  return [
+    [
+      (m[1][1] * c5 - m[1][2] * c4 + m[1][3] * c3) * determinant,
+      (-m[0][1] * c5 + m[0][2] * c4 - m[0][3] * c3) * determinant,
+      (m[3][1] * s5 - m[3][2] * s4 + m[3][3] * s3) * determinant,
+      (-m[2][1] * s5 + m[2][2] * s4 - m[2][3] * s3) * determinant,
+    ], [
+      (-m[1][0] * c5 + m[1][2] * c2 - m[1][3] * c1) * determinant,
+      (m[0][0] * c5 - m[0][2] * c2 + m[0][3] * c1) * determinant,
+      (-m[3][0] * s5 + m[3][2] * s2 - m[3][3] * s1) * determinant,
+      (m[2][0] * s5 - m[2][2] * s2 + m[2][3] * s1) * determinant,
+    ], [
+      (m[1][0] * c4 - m[1][1] * c2 + m[1][3] * c0) * determinant,
+      (-m[0][0] * c4 + m[0][1] * c2 - m[0][3] * c0) * determinant,
+      (m[3][0] * s4 - m[3][1] * s2 + m[3][3] * s0) * determinant,
+      (-m[2][0] * s4 + m[2][1] * s2 - m[2][3] * s0) * determinant,
+    ], [
+      (-m[1][0] * c3 + m[1][1] * c1 - m[1][2] * c0) * determinant,
+      (m[0][0] * c3 - m[0][1] * c1 + m[0][2] * c0) * determinant,
+      (-m[3][0] * s3 + m[3][1] * s1 - m[3][2] * s0) * determinant,
+      (m[2][0] * s3 - m[2][1] * s1 + m[2][2] * s0) * determinant,
+    ],
+  ]
+}
+
+export {
+  getTransform,
+  getTransformOrigin,
+  translateMatrix,
+  identity,
+  roundTo,
+  multiply,
+  computeTransformMatrix,
+  transformVertex,
+  projectVertex,
+  inverse,
+}

--- a/elements/openlayers-core/ol-layer-vector.ts
+++ b/elements/openlayers-core/ol-layer-vector.ts
@@ -2,6 +2,7 @@ import VectorLayer from 'ol/layer/Vector.js'
 import VectorSource from 'ol/source/Vector.js'
 import { property } from 'lit/decorators.js'
 import Style, { StyleFunction } from 'ol/style/Style.js'
+import type { FlatStyle } from 'ol/style/flat.js'
 import OlLayerBase from './ol-layer-base.js'
 import AttachableAwareMixin from './mixins/AttachableAware.js'
 
@@ -35,13 +36,13 @@ export default class OlLayerVector extends AttachableAwareMixin(
   public source?: VectorSource = undefined
 
   /**
-   * The style to be applied to layer features. It can be either an `ol/Style`, array thereof,
-   * or a function which returns either.
+   * The style to be applied to layer features. It can be either an `ol/Style` or `ol/style/flat`
+   * array thereof, or a function which returns either.
    *
-   * @type {Style | Style[] | StyleFunction}
+   * @type {Style | Style[] | FlatStyle | FlatStyle[] | StyleFunction}
    */
   @property({ type: Object })
-  public featureStyle?: Style | Style[] | StyleFunction = undefined
+  public featureStyle?: Style | Style[] | FlatStyle | FlatStyle[] | StyleFunction = undefined
 
   public fit() {
     if (this.source) {

--- a/elements/openlayers-core/ol-map.ts
+++ b/elements/openlayers-core/ol-map.ts
@@ -198,7 +198,7 @@ export default class OlMap extends AttachableAwareMixin(LitElement, 'map') {
 
   public render() {
     return html`
-      <link rel="stylesheet" href="https://openlayers.org/en/v6.5.0/css/ol.css" type="text/css" />
+      <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/ol@v9.2.4/ol.css" type="text/css" />
       <style>
         :host {
           display: block;

--- a/elements/openlayers-core/package.json
+++ b/elements/openlayers-core/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "lit": "^3.1.4",
-    "ol": "^8.0.0"
+    "ol": "^9.2.4"
   },
   "devDependencies": {
     "@open-wc/testing": "^4.0.0",

--- a/elements/openlayers-core/package.json
+++ b/elements/openlayers-core/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "lit": "^3.1.4",
-    "ol": "^7.5.0"
+    "ol": "^8.0.0"
   },
   "devDependencies": {
     "@open-wc/testing": "^4.0.0",

--- a/elements/openlayers-elements/ol-marker-icon.ts
+++ b/elements/openlayers-elements/ol-marker-icon.ts
@@ -168,6 +168,18 @@ export default class OlMarkerIcon extends OlFeature {
       }),
     )
 
+    // // TODO update to flat style format
+    // feature.setStyle(
+    //   new Style(this.__iconInit),
+    // )
+    // // Example properties
+    // this.__iconInit = {
+    //   'icon-src': '../images/icon.png',
+    //   'icon-scale': 2,
+    //   'icon-size': [16, 16],
+    //   'icon-offset': [32, 64],
+    // }
+
     return feature
   }
 

--- a/elements/openlayers-elements/ol-marker-icon.ts
+++ b/elements/openlayers-elements/ol-marker-icon.ts
@@ -3,10 +3,10 @@ import { property } from 'lit/decorators.js'
 import Feature from 'ol/Feature.js'
 import Point from 'ol/geom/Point.js'
 import { fromLonLat } from 'ol/proj.js'
-import Icon, { Options } from 'ol/style/Icon.js'
+import { Style, Icon } from 'ol/style.js'
 import type { IconAnchorUnits, IconOrigin } from 'ol/style/Icon.js'
-import Style from 'ol/style/Style.js'
-import { Size } from 'ol/size.js'
+import type { FlatIcon } from 'ol/style/flat.js'
+import type { Size } from 'ol/size.js'
 import OlMap from './ol-map.js'
 
 /**
@@ -25,7 +25,7 @@ import OlMap from './ol-map.js'
  * To position the marker on the map, a combination of its properties have to be used
  *
  * 1. The base position is either `[x, y]` or `[lat, lon]`
- * 1. The anchor on the map is by default the image's center and can be change by setting the `anchor*` properties
+ * 1. The anchor on the map is by default the image's center and can be changed by setting the `anchor*` properties
  *
  * For an in-depth description of individual properties go to OpenLayer's docs for [ol/Style/Icon](https://openlayers.org/en/latest/apidoc/module-ol_style_Icon.html)
  */
@@ -119,8 +119,8 @@ export default class OlMarkerIcon extends OlFeature {
   /**
    * @type {IconOrigin}
    */
-  @property({ type: Number, attribute: 'offset-origin' })
-  public offsetOrigin: IconOrigin
+  @property({ type: String, attribute: 'offset-origin' })
+  public offsetOrigin?: IconOrigin = undefined
 
   /**
    * @type {number}
@@ -149,7 +149,7 @@ export default class OlMarkerIcon extends OlFeature {
   /**
    * @type {Size}
    */
-  @property({ type: Number })
+  @property({ type: Array })
   public size?: Size = undefined
 
   public createFeature(map: OlMap | undefined) {
@@ -162,44 +162,59 @@ export default class OlMarkerIcon extends OlFeature {
       geometry: point,
     })
 
-    feature.setStyle(
-      new Style({
-        image: new Icon(this.__iconInit),
-      }),
-    )
-
-    // // TODO update to flat style format
-    // feature.setStyle(
-    //   new Style(this.__iconInit),
-    // )
-    // // Example properties
-    // this.__iconInit = {
-    //   'icon-src': '../images/icon.png',
-    //   'icon-scale': 2,
-    //   'icon-size': [16, 16],
-    //   'icon-offset': [32, 64],
-    // }
+    feature.setStyle(this.flatIconToStyle(this.__iconInit))
 
     return feature
   }
 
-  private get __iconInit(): Options {
+  private get __iconInit(): FlatIcon {
     return {
-      anchor: [this.anchorX, this.anchorY],
-      anchorOrigin: this.anchorOrigin,
-      anchorXUnits: this.anchorXUnits,
-      anchorYUnits: this.anchorYUnits,
-      color: this.color,
-      crossOrigin: this.crossOrigin,
-      offset: [this.offsetX, this.offsetY],
-      offsetOrigin: this.offsetOrigin,
-      opacity: this.opacity,
-      scale: this.scale,
-      rotateWithView: this.rotateWithView,
-      rotation: this.rotation,
-      size: this.size,
-      src: this.src,
+      'icon-anchor': [this.anchorX, this.anchorY],
+      'icon-anchor-origin': this.anchorOrigin,
+      'icon-anchor-x-units': this.anchorXUnits,
+      'icon-anchor-y-units': this.anchorYUnits,
+      'icon-color': this.color,
+      'icon-cross-origin': this.crossOrigin,
+      'icon-offset': [this.offsetX, this.offsetY],
+      'icon-offset-origin': this.offsetOrigin,
+      'icon-opacity': this.opacity,
+      'icon-scale': this.scale,
+      'icon-rotate-with-view': this.rotateWithView,
+      'icon-rotation': this.rotation,
+      'icon-size': this.size,
+      'icon-src': this.src,
     }
+  }
+
+  /**
+   * Converts a FlatIcon object to an OpenLayers Style object.
+   *
+   * OpenLayers does not directly support passing styles as FlatIcon objects to Features.
+   * This method serves as a workaround to convert a FlatIcon object, which uses the
+   * flatstyle format, into an OpenLayers Style object that can be applied to a Feature.
+   *
+   * @param {FlatIcon} flatIcon - The FlatIcon object containing style properties.
+   * @returns {Style} - The OpenLayers Style object.
+   */
+  private flatIconToStyle(flatIcon: FlatIcon) {
+    return new Style({
+      image: new Icon({
+        anchor: flatIcon['icon-anchor'] as number[],
+        anchorOrigin: flatIcon['icon-anchor-origin'] as IconOrigin,
+        anchorXUnits: flatIcon['icon-anchor-x-units'] as IconAnchorUnits,
+        anchorYUnits: flatIcon['icon-anchor-y-units'] as IconAnchorUnits,
+        color: flatIcon['icon-color'] as string,
+        crossOrigin: flatIcon['icon-cross-origin'] as string,
+        offset: flatIcon['icon-offset'] as number[],
+        offsetOrigin: flatIcon['icon-offset-origin'] as IconOrigin,
+        opacity: flatIcon['icon-opacity'] as number,
+        scale: flatIcon['icon-scale'] as number,
+        rotation: flatIcon['icon-rotation'] as number,
+        rotateWithView: flatIcon['icon-rotate-with-view'] as boolean,
+        size: flatIcon['icon-size'] as Size,
+        src: flatIcon['icon-src'] as string,
+      }),
+    })
   }
 }
 

--- a/elements/openlayers-elements/package.json
+++ b/elements/openlayers-elements/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@openlayers-elements/core": "^0.3.0",
     "lit": "^3.1.4",
-    "ol": "^8.0.0",
+    "ol": "^9.2.4",
     "resize-observer-polyfill": "^1.5.1"
   },
   "devDependencies": {

--- a/elements/openlayers-elements/package.json
+++ b/elements/openlayers-elements/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@openlayers-elements/core": "^0.3.0",
     "lit": "^3.1.4",
-    "ol": "^7.5.0",
+    "ol": "^8.0.0",
     "resize-observer-polyfill": "^1.5.1"
   },
   "devDependencies": {

--- a/elements/swisstopo-elements/package.json
+++ b/elements/swisstopo-elements/package.json
@@ -22,7 +22,7 @@
     "@openlayers-elements/core": "^0.3.0",
     "@openlayers-elements/maps": "^0.3.0",
     "lit": "^3.1.4",
-    "ol": "^8.0.0",
+    "ol": "^9.2.4",
     "proj4": "^2.5.0"
   },
   "devDependencies": {

--- a/elements/swisstopo-elements/package.json
+++ b/elements/swisstopo-elements/package.json
@@ -22,7 +22,7 @@
     "@openlayers-elements/core": "^0.3.0",
     "@openlayers-elements/maps": "^0.3.0",
     "lit": "^3.1.4",
-    "ol": "^7.5.0",
+    "ol": "^8.0.0",
     "proj4": "^2.5.0"
   },
   "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14256,6 +14256,36 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/color-parse": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-2.0.2.tgz",
+      "integrity": "sha512-eCtOz5w5ttWIUcaKLiktF+DxZO1R9KLNY/xhbV6CkhM7sR3GhVghmt6X6yOnzeaM24po+Z9/S1apbXMwA3Iepw==",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      }
+    },
+    "node_modules/color-parse/node_modules/color-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.0.tgz",
+      "integrity": "sha512-SbtvAMWvASO5TE2QP07jHBMXKafgdZz8Vrsrn96fiL+O92/FN/PLARzUW5sKt013fjAprK2d2iCn2hk2Xb5oow==",
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/color-rgba": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/color-rgba/-/color-rgba-3.0.0.tgz",
+      "integrity": "sha512-PPwZYkEY3M2THEHHV6Y95sGUie77S7X8v+h1r6LSAPF3/LL2xJ8duUXSrkic31Nzc4odPwHgUbiX/XuTYzQHQg==",
+      "dependencies": {
+        "color-parse": "^2.0.0",
+        "color-space": "^2.0.0"
+      }
+    },
+    "node_modules/color-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-space/-/color-space-2.0.1.tgz",
+      "integrity": "sha512-nKqUYlo0vZATVOFHY810BSYjmCARrG7e5R3UE3CQlyjJTvv5kSSmPG1kzm/oDyyqjehM+lW1RnEt9It9GNa5JA=="
+    },
     "node_modules/colorette": {
       "version": "2.0.20",
       "dev": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -3959,45 +3959,6 @@
         "node": ">=6 <7 || >=8"
       }
     },
-    "node_modules/@mapbox/jsonlint-lines-primitives": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
-      "integrity": "sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ==",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/@mapbox/mapbox-gl-style-spec": {
-      "version": "13.28.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-style-spec/-/mapbox-gl-style-spec-13.28.0.tgz",
-      "integrity": "sha512-B8xM7Fp1nh5kejfIl4SWeY0gtIeewbuRencqO3cJDrCHZpaPg7uY+V8abuR+esMeuOjRl5cLhVTP40v+1ywxbg==",
-      "dependencies": {
-        "@mapbox/jsonlint-lines-primitives": "~2.0.2",
-        "@mapbox/point-geometry": "^0.1.0",
-        "@mapbox/unitbezier": "^0.0.0",
-        "csscolorparser": "~1.0.2",
-        "json-stringify-pretty-compact": "^2.0.0",
-        "minimist": "^1.2.6",
-        "rw": "^1.3.3",
-        "sort-object": "^0.3.2"
-      },
-      "bin": {
-        "gl-style-composite": "bin/gl-style-composite.js",
-        "gl-style-format": "bin/gl-style-format.js",
-        "gl-style-migrate": "bin/gl-style-migrate.js",
-        "gl-style-validate": "bin/gl-style-validate.js"
-      }
-    },
-    "node_modules/@mapbox/point-geometry": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz",
-      "integrity": "sha512-6j56HdLTwWGO0fJPlrZtdU/B13q8Uwmo18Ck2GnGgN9PCFyKTZ3UbXeEdRFh18i9XQ92eH2VdtpJHpBD3aripQ=="
-    },
-    "node_modules/@mapbox/unitbezier": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.0.tgz",
-      "integrity": "sha512-HPnRdYO0WjFjRTSwO3frz1wKaU649OBFPX3Zo/2WZvuRi6zMiRGui8SnPQiQABgqCf8YikDe5t3HViTVw1WUzA=="
-    },
     "node_modules/@mdn/browser-compat-data": {
       "version": "4.2.1",
       "dev": true,
@@ -19992,6 +19953,7 @@
     },
     "node_modules/minimist": {
       "version": "1.2.8",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -20553,29 +20515,20 @@
       "license": "MIT"
     },
     "node_modules/ol": {
-      "version": "7.5.2",
-      "resolved": "https://registry.npmjs.org/ol/-/ol-7.5.2.tgz",
-      "integrity": "sha512-HJbb3CxXrksM6ct367LsP3N+uh+iBBMdP3DeGGipdV9YAYTP0vTJzqGnoqQ6C2IW4qf8krw9yuyQbc9fjOIaOQ==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/ol/-/ol-8.2.0.tgz",
+      "integrity": "sha512-/m1ddd7Jsp4Kbg+l7+ozR5aKHAZNQOBAoNZ5pM9Jvh4Etkf0WGkXr9qXd7PnhmwiC1Hnc2Toz9XjCzBBvexfXw==",
       "dependencies": {
+        "color-rgba": "^3.0.0",
+        "color-space": "^2.0.1",
         "earcut": "^2.2.3",
         "geotiff": "^2.0.7",
-        "ol-mapbox-style": "^10.1.0",
         "pbf": "3.2.1",
         "rbush": "^3.0.1"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/openlayers"
-      }
-    },
-    "node_modules/ol-mapbox-style": {
-      "version": "10.7.0",
-      "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-10.7.0.tgz",
-      "integrity": "sha512-S/UdYBuOjrotcR95Iq9AejGYbifKeZE85D9VtH11ryJLQPTZXZSW1J5bIXcr4AlAH6tyjPPHTK34AdkwB32Myw==",
-      "dependencies": {
-        "@mapbox/mapbox-gl-style-spec": "^13.23.1",
-        "mapbox-to-css-font": "^2.4.1",
-        "ol": "^7.3.0"
       }
     },
     "node_modules/on-finished": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20515,9 +20515,9 @@
       "license": "MIT"
     },
     "node_modules/ol": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/ol/-/ol-8.2.0.tgz",
-      "integrity": "sha512-/m1ddd7Jsp4Kbg+l7+ozR5aKHAZNQOBAoNZ5pM9Jvh4Etkf0WGkXr9qXd7PnhmwiC1Hnc2Toz9XjCzBBvexfXw==",
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/ol/-/ol-9.2.4.tgz",
+      "integrity": "sha512-bsbu4ObaAlbELMIZWnYEvX4Z9jO+OyCBshtODhDKmqYTPEfnKOX3RieCr97tpJkqWTZvyV4tS9UQDvHoCdxS+A==",
       "dependencies": {
         "color-rgba": "^3.0.0",
         "color-space": "^2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22539,34 +22539,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/sort-asc": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/sort-asc/-/sort-asc-0.1.0.tgz",
-      "integrity": "sha512-jBgdDd+rQ+HkZF2/OHCmace5dvpos/aWQpcxuyRs9QUbPRnkEJmYVo81PIGpjIdpOcsnJ4rGjStfDHsbn+UVyw==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/sort-desc": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/sort-desc/-/sort-desc-0.1.1.tgz",
-      "integrity": "sha512-jfZacW5SKOP97BF5rX5kQfJmRVZP5/adDUTY8fCSPvNcXDVpUEe2pr/iKGlcyZzchRJZrswnp68fgk3qBXgkJw==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/sort-object": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/sort-object/-/sort-object-0.3.2.tgz",
-      "integrity": "sha512-aAQiEdqFTTdsvUFxXm3umdo04J7MRljoVGbBlkH7BgNsMvVNAJyGj7C/wV1A8wHWAJj/YikeZbfuCKqhggNWGA==",
-      "dependencies": {
-        "sort-asc": "^0.1.0",
-        "sort-desc": "^0.1.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "dev": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -447,7 +447,7 @@
       "license": "MIT",
       "dependencies": {
         "lit": "^3.1.4",
-        "ol": "^7.5.0"
+        "ol": "^9.2.4"
       },
       "devDependencies": {
         "@open-wc/testing": "^4.0.0",
@@ -487,7 +487,7 @@
       "dependencies": {
         "@openlayers-elements/core": "^0.3.0",
         "lit": "^3.1.4",
-        "ol": "^7.5.0",
+        "ol": "^9.2.4",
         "resize-observer-polyfill": "^1.5.1"
       },
       "devDependencies": {
@@ -528,7 +528,7 @@
         "@openlayers-elements/core": "^0.3.0",
         "@openlayers-elements/maps": "^0.3.0",
         "lit": "^3.1.4",
-        "ol": "^7.5.0",
+        "ol": "^9.2.4",
         "proj4": "^2.5.0"
       },
       "devDependencies": {
@@ -14466,11 +14466,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/csscolorparser": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/csscolorparser/-/csscolorparser-1.0.3.tgz",
-      "integrity": "sha512-umPSgYwZkdFoUrH5hIq5kf0wPSXiro51nPw0j2K/c83KflkPSTBGMz6NJvMB+07VlL0y7VPo6QJcDjcgKTTm3w=="
-    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "dev": true,
@@ -18899,11 +18894,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/json-stringify-pretty-compact": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-2.0.0.tgz",
-      "integrity": "sha512-WRitRfs6BGq4q8gTgOy4ek7iPFXjbra0H3PmDLKm2xnZ+Gh1HUhiKGgCZkSPNULlP7mvfu6FV/mOLhCarspADQ=="
-    },
     "node_modules/json5": {
       "version": "1.0.2",
       "dev": true,
@@ -19832,11 +19822,6 @@
       "version": "1.5.0",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/mapbox-to-css-font": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/mapbox-to-css-font/-/mapbox-to-css-font-2.4.4.tgz",
-      "integrity": "sha512-X1dtuTuH2D1MRMuductMZCLV/fy9EoIgqW/lmu8vQSAhEatx/tdFebkYT3TVhdTwqFDHbLEgQBD3IKA4KI7aoQ=="
     },
     "node_modules/markdown-to-jsx": {
       "version": "7.3.2",
@@ -22117,11 +22102,6 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
-    },
-    "node_modules/rw": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
-      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="
     },
     "node_modules/safe-array-concat": {
       "version": "1.1.2",

--- a/storybook/.storybook/main.ts
+++ b/storybook/.storybook/main.ts
@@ -10,7 +10,7 @@ function getAbsolutePath(value: string) {
 }
 
 const config: StorybookConfig = {
-  stories: ['../stories/**/*.mdx', '../stories/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
+  stories: ['../stories/**/*.mdx', '../stories/**/*.stories.@(ts|tsx)'],
   addons: [
     getAbsolutePath('@storybook/addon-links'),
     getAbsolutePath('@storybook/addon-essentials'),

--- a/storybook/package.json
+++ b/storybook/package.json
@@ -25,7 +25,7 @@
     "custom-elements-manifest": "cem analyze --globs \"../elements/*/*.ts\" --litelement",
     "custom-elements-manifest:watch": "npm run custom-elements-manifest -- --watch",
     "prestorybook": "npm run custom-elements-manifest",
-    "storybook": "storybook dev -p 6006",
+    "storybook": "storybook dev -p 6006 --no-open",
     "prebuild": "npm run custom-elements-manifest",
     "build": "storybook build"
   }

--- a/storybook/stories/Map.stories.ts
+++ b/storybook/stories/Map.stories.ts
@@ -20,6 +20,9 @@ const main: Meta = {
     zoom: {
       control: 'number',
     },
+    pitch: {
+      control: 'number',
+    },
   },
 }
 
@@ -30,10 +33,9 @@ export const Basic: Story = {
   args: {
     zoom: 7,
   },
-  render: args => html`
-<ol-map ${spread(args)}>
-  <ol-layer-openstreetmap></ol-layer-openstreetmap>
-</ol-map>`,
+  render: args => html` <ol-map ${spread(args)}>
+      <ol-layer-openstreetmap></ol-layer-openstreetmap>
+    </ol-map>`,
 }
 
 /**
@@ -47,26 +49,26 @@ export const ZoomToLayer: Story = {
     lon: -98.5795,
   },
   render: args => html`
-<style>
-  ol-map {
-    --zoom-control-top: 10px;
-    --zoom-control-right: 10px;
-  }
-</style>
+    <style>
+      ol-map {
+        --zoom-control-top: 10px;
+        --zoom-control-right: 10px;
+      }
+    </style>
 
-<ol-map ${spread(args)}>
-  <ol-layer-openstreetmap></ol-layer-openstreetmap>
-  <ol-layer-geojson url="/europe.geojson"></ol-layer-geojson>
-  <ol-control id="zoom">
-    <button onclick="goToEurope()">Go to Europe</button>
-  </ol-control>
-</ol-map>
+    <ol-map ${spread(args)}>
+      <ol-layer-openstreetmap></ol-layer-openstreetmap>
+      <ol-layer-geojson url="/europe.geojson"></ol-layer-geojson>
+      <ol-control id="zoom">
+        <button onclick="goToEurope()">Go to Europe</button>
+      </ol-control>
+    </ol-map>
 
-<script>
-  function goToEurope() {
-    document.querySelector('ol-layer-geoJson').fit()
-  }
-</script>
+    <script>
+      function goToEurope() {
+        document.querySelector('ol-layer-geoJson').fit()
+      }
+    </script>
   `,
 }
 
@@ -83,20 +85,32 @@ export const ZoomToExtent: Story = {
     zoom: 4,
     zoomDuration: 400,
   },
-  render: ({ zoomDuration, ...args }) => html`
-<ol-map ${spread(args)}>
-  <ol-layer-openstreetmap></ol-layer-openstreetmap>
-  <ol-layer-geojson
-    url="/countries.geojson"
-  ></ol-layer-geojson>
-  <ol-select @feature-selected="${(e) => {
+  render: ({ zoomDuration, ...args }) => html` <ol-map ${spread(args)}>
+      <ol-layer-openstreetmap></ol-layer-openstreetmap>
+      <ol-layer-geojson url="/countries.geojson"></ol-layer-geojson>
+      <ol-select
+        @feature-selected="${(e) => {
     e.target._map.fit(e.detail.feature.getGeometry().getExtent(), {
       duration: zoomDuration,
     })
-  }}"></ol-select>
-</ol-map>`,
+  }}"
+      ></ol-select>
+    </ol-map>`,
   beforeEach: async () => {
     await import('@openlayers-elements/maps/ol-layer-geojson.js')
     await import('@openlayers-elements/maps/ol-select.js')
   },
+}
+
+export const PerspectiveMap: Story = {
+  name: 'Perspective Map (Tilt)',
+  args: {
+    zoom: 17,
+    lat: 51.522418,
+    lon: -0.15017,
+    pitch: 20,
+  },
+  render: args => html` <ol-map ${spread(args)}>
+      <ol-layer-openstreetmap></ol-layer-openstreetmap>
+    </ol-map>`,
 }


### PR DESCRIPTION
## Related Issue

Fixes #131

## Describe this PR

- Adds a parameter `pitch` to ol-map. An integer between 0-30.
- If enabled, the map is rendered with a pitched perspective, I.e. a tilted map, navigation-like view.
- Includes logic under `lib` for the 3D matrix calculations.

Todo (will get back to this soon!)
- [ ] Works as intended, but there is one minor console warning from Lit about multiple subsequent rerenders.
- [ ] Add changeset
- [ ] Add tests

## Screenshots

Please provide screenshots of the change.

## Alternative Approaches Considered

Did you attempt any other approaches that are not documented in code?

## Checklist before requesting a review

- [x] Information about the PR, including descriptive commits and link to issue
- [ ] All tests are passing
  - Run tests locally with: `npm run test`, or view via the CI workflow.
- [ ] Includes a changeset, if required.
  - Run `npx changeset`.
