### PR TITLE
feat: ol-select#feature-style

### DIFF
--- a/.changeset/mean-fireants-drum.md
+++ b/.changeset/mean-fireants-drum.md
@@ -1,0 +1,5 @@
+---
+'@openlayers-elements/core': patch
+---
+
+Added a `fromJson` in `Style.js` module, which allows converting element attributes to OL styles

--- a/.changeset/purple-hornets-switch.md
+++ b/.changeset/purple-hornets-switch.md
@@ -1,0 +1,5 @@
+---
+'@openlayers-elements/maps': patch
+---
+
+Remove unused dependency `resize-observer-polyfill`

--- a/.changeset/shy-experts-marry.md
+++ b/.changeset/shy-experts-marry.md
@@ -1,0 +1,5 @@
+---
+'@openlayers-elements/maps': patch
+---
+
+`ol-style`: added `featureStyle` property

--- a/.github/workflows/netlify.yaml
+++ b/.github/workflows/netlify.yaml
@@ -1,6 +1,7 @@
 name: Netlify
 
-on: push
+on:
+  pull_request:
 
 jobs:
   Deploy:

--- a/.github/workflows/netlify.yaml
+++ b/.github/workflows/netlify.yaml
@@ -16,7 +16,7 @@ jobs:
       - uses: Wohlstand/branch-name@v1.0.2-wohl
 
       - name: Publish preview
-        uses: jsmrcaga/action-netlify-deploy@v2.2.0
+        uses: jsmrcaga/action-netlify-deploy@netlify-not-found
         if: env.NETLIFY_AUTH_TOKEN
         with:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}

--- a/elements/openlayers-core/Style.ts
+++ b/elements/openlayers-core/Style.ts
@@ -1,0 +1,5 @@
+import { loadStyle } from 'ol-json-style' // eslint-disable-line import/no-extraneous-dependencies
+
+export function fromJson(json: string | null) {
+  return json ? loadStyle(JSON.parse(json)) : null
+}

--- a/elements/openlayers-core/esbuild.config.json
+++ b/elements/openlayers-core/esbuild.config.json
@@ -4,7 +4,6 @@
   "format": "esm",
   "external": [
     "ol",
-    "@openlayers-elements/*",
     "lit*",
     "@lit/*"
   ]

--- a/elements/openlayers-core/package.json
+++ b/elements/openlayers-core/package.json
@@ -12,14 +12,14 @@
     "*.d.ts",
     "mixins/*.js",
     "mixins/*.d.ts",
-    "lib/*.js",
-    "lib/*.d.ts",
     "custom-elements.json"
   ],
   "license": "MIT",
   "scripts": {
     "custom-elements-manifest": "cem analyze --litelement",
-    "build": "tsc",
+    "build:dts": "tsc --emitDeclarationOnly",
+    "build:js": "esbuild *.ts $(esbuild-config ./esbuild.config.json)",
+    "build": "npm run build:dts && npm run build:js",
     "prepack": "npm run build && npm run custom-elements-manifest"
   },
   "dependencies": {
@@ -29,6 +29,7 @@
   "devDependencies": {
     "@open-wc/testing": "^4.0.0",
     "sinon": "^9.2.4",
+    "ol-json-style": "^1.0.3",
     "@openlayers-elements/testing": "0.1.0"
   },
   "publishConfig": {

--- a/elements/openlayers-elements/esbuild.config.json
+++ b/elements/openlayers-elements/esbuild.config.json
@@ -1,0 +1,11 @@
+{
+  "outdir": ".",
+  "bundle": true,
+  "format": "esm",
+  "external": [
+    "ol",
+    "@openlayers-elements/*",
+    "lit*",
+    "@lit/*"
+  ]
+}

--- a/elements/openlayers-elements/ol-select.ts
+++ b/elements/openlayers-elements/ol-select.ts
@@ -3,7 +3,7 @@ import OlInteraction from '@openlayers-elements/core/ol-interaction.js'
 import { StyleLike } from 'ol/style/Style.js'
 import type Feature from 'ol/Feature.js'
 import { property } from 'lit/decorators.js'
-import { loadStyle } from 'ol-json-style' // eslint-disable-line import/no-extraneous-dependencies
+import * as Style from '@openlayers-elements/core/Style.js'
 
 /**
  * Non-visual element which enables selecting map features
@@ -35,7 +35,7 @@ export class OlSelect extends OlInteraction {
   @property({
     type: Object,
     attribute: 'feature-style',
-    converter: loadStyle,
+    converter: Style.fromJson,
   })
   public featureStyle?: StyleLike
 

--- a/elements/openlayers-elements/ol-select.ts
+++ b/elements/openlayers-elements/ol-select.ts
@@ -1,5 +1,9 @@
 import Select from 'ol/interaction/Select.js'
 import OlInteraction from '@openlayers-elements/core/ol-interaction.js'
+import { StyleLike } from 'ol/style/Style.js'
+import type Feature from 'ol/Feature.js'
+import { property } from 'lit/decorators.js'
+import { loadStyle } from 'ol-json-style' // eslint-disable-line import/no-extraneous-dependencies
 
 /**
  * Non-visual element which enables selecting map features
@@ -28,13 +32,24 @@ export class OlSelect extends OlInteraction {
    * @event feature-unselected
    */
 
+  @property({
+    type: Object,
+    attribute: 'feature-style',
+    converter: loadStyle,
+  })
+  public featureStyle?: StyleLike
+
   public async createPart() {
     const select = new Select()
 
     select.on(['select'], (e: any) => {
-      const feature = e.selected[0]
+      const feature: Feature | undefined = e.selected[0]
 
       if (feature) {
+        if (this.featureStyle) {
+          feature.setStyle(this.featureStyle)
+        }
+
         this.dispatchEvent(
           new CustomEvent('feature-selected', {
             detail: { feature },

--- a/elements/openlayers-elements/package.json
+++ b/elements/openlayers-elements/package.json
@@ -16,17 +16,20 @@
   "license": "MIT",
   "scripts": {
     "custom-elements-manifest": "cem analyze --litelement",
-    "build": "tsc",
+    "build:dts": "tsc --emitDeclarationOnly",
+    "build:js": "esbuild *.ts $(esbuild-config ./esbuild.config.json)",
+    "build": "npm run build:dts && npm run build:js",
     "prepack": "npm run build && npm run custom-elements-manifest"
   },
   "dependencies": {
     "@openlayers-elements/core": "^0.3.0",
     "lit": "^3.1.4",
-    "ol": "^7.5.0",
-    "resize-observer-polyfill": "^1.5.1"
+    "ol": "^7.5.0"
   },
   "devDependencies": {
     "@open-wc/testing": "^4.0.0",
+    "esbuild-config": "^1",
+    "ol-json-style": "github:pilattebe/ol-json-styles#main",
     "sinon": "^9.2.4"
   },
   "publishConfig": {

--- a/elements/openlayers-elements/package.json
+++ b/elements/openlayers-elements/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "@open-wc/testing": "^4.0.0",
     "esbuild-config": "^1",
-    "ol-json-style": "github:pilattebe/ol-json-styles#main",
+    "ol-json-style": "^1.0.3",
     "sinon": "^9.2.4"
   },
   "publishConfig": {

--- a/elements/openlayers-elements/package.json
+++ b/elements/openlayers-elements/package.json
@@ -16,9 +16,7 @@
   "license": "MIT",
   "scripts": {
     "custom-elements-manifest": "cem analyze --litelement",
-    "build:dts": "tsc --emitDeclarationOnly",
-    "build:js": "esbuild *.ts $(esbuild-config ./esbuild.config.json)",
-    "build": "npm run build:dts && npm run build:js",
+    "build": "tsc",
     "prepack": "npm run build && npm run custom-elements-manifest"
   },
   "dependencies": {
@@ -29,7 +27,6 @@
   "devDependencies": {
     "@open-wc/testing": "^4.0.0",
     "esbuild-config": "^1",
-    "ol-json-style": "^1.0.3",
     "sinon": "^9.2.4"
   },
   "publishConfig": {

--- a/elements/openlayers-elements/test/ol-select.test.ts
+++ b/elements/openlayers-elements/test/ol-select.test.ts
@@ -1,0 +1,21 @@
+import '../ol-select.js'
+import { expect, fixture } from '@open-wc/testing'
+import Style from 'ol/style/Style.js'
+import type { OlSelect } from '../ol-select.js'
+
+describe('ol-style', () => {
+  describe('feature style', () => {
+    it('can be set from attribute', async () => {
+      // given
+      const element = await fixture<OlSelect>(`<ol-select feature-style='{ "Style": {
+    "fill": { "Fill": {
+      "color": "rgba(255,255,255,0.4)"
+    }}
+  }}'></ol-select>`)
+
+      // then
+      const style = element.featureStyle as Style
+      expect(style.getFill().getColor()).to.deep.equal('rgba(255,255,255,0.4)')
+    })
+  })
+})

--- a/global.d.ts
+++ b/global.d.ts
@@ -1,0 +1,4 @@
+declare module "ol-json-style" {
+  import { StyleLike } from 'ol/style/Style'
+  export function loadStyle(value: any): StyleLike
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -116,6 +116,7 @@
       "devDependencies": {
         "@open-wc/testing": "^4.0.0",
         "@openlayers-elements/testing": "0.1.0",
+        "ol-json-style": "^1.0.3",
         "sinon": "^9.2.4"
       }
     },
@@ -156,7 +157,6 @@
       "devDependencies": {
         "@open-wc/testing": "^4.0.0",
         "esbuild-config": "^1",
-        "ol-json-style": "^1.0.3",
         "sinon": "^9.2.4"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "eslint": "^8",
         "eslint-import-resolver-typescript": "^3.6.1",
         "husky": "^9",
-        "lint-staged": "^13.0.3",
+        "lint-staged": "^13.3.0",
         "prettier": "^1.16.4",
         "typescript": "^5.4.5"
       }
@@ -151,11 +151,12 @@
       "dependencies": {
         "@openlayers-elements/core": "^0.3.0",
         "lit": "^3.1.4",
-        "ol": "^7.5.0",
-        "resize-observer-polyfill": "^1.5.1"
+        "ol": "^7.5.0"
       },
       "devDependencies": {
         "@open-wc/testing": "^4.0.0",
+        "esbuild-config": "^1",
+        "ol-json-style": "github:pilattebe/ol-json-styles#main",
         "sinon": "^9.2.4"
       }
     },
@@ -7563,6 +7564,16 @@
         "@esbuild/win32-x64": "0.19.12"
       }
     },
+    "node_modules/esbuild-config": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/esbuild-config/-/esbuild-config-1.0.1.tgz",
+      "integrity": "sha512-3Ha0LwC9F1Y1+rertxsDvaSWp+XyvIvI4Lrh3XNcZpuD2qz9xaHUY0yK9ESgh7AplfwVJDYAtOsAStYyArRhXA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild-config": "bin/esbuild-config"
+      }
+    },
     "node_modules/esbuild-register": {
       "version": "3.5.0",
       "dev": true,
@@ -11946,6 +11957,15 @@
         "url": "https://opencollective.com/openlayers"
       }
     },
+    "node_modules/ol-json-style": {
+      "version": "1.0.3",
+      "resolved": "git+ssh://git@github.com/pilattebe/ol-json-styles.git#adc96d6f470eea8625318a4d5df4c09c3cf7e7d5",
+      "dev": true,
+      "license": "BSD 2-Clause \"Simplified\" ",
+      "dependencies": {
+        "ol": ">=6"
+      }
+    },
     "node_modules/ol-mapbox-style": {
       "version": "10.7.0",
       "license": "BSD-2-Clause",
@@ -12179,6 +12199,24 @@
     "node_modules/parse-headers": {
       "version": "2.0.5",
       "license": "MIT"
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/parse5": {
       "version": "6.0.1",
@@ -12990,23 +13028,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/read-pkg/node_modules/parse-json": {
-      "version": "5.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.0.0",
-        "error-ex": "^1.3.1",
-        "json-parse-even-better-errors": "^2.3.0",
-        "lines-and-columns": "^1.1.6"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/read-pkg/node_modules/type-fest": {
       "version": "0.6.0",
       "dev": true,
@@ -13231,10 +13252,6 @@
       "engines": {
         "node": ">=0.10.5"
       }
-    },
-    "node_modules/resize-observer-polyfill": {
-      "version": "1.5.1",
-      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -156,7 +156,7 @@
       "devDependencies": {
         "@open-wc/testing": "^4.0.0",
         "esbuild-config": "^1",
-        "ol-json-style": "github:pilattebe/ol-json-styles#main",
+        "ol-json-style": "^1.0.3",
         "sinon": "^9.2.4"
       }
     },

--- a/storybook/.storybook/preview-head.html
+++ b/storybook/.storybook/preview-head.html
@@ -18,9 +18,9 @@
 </style>
 
 <script type="module">
-  import Style from 'ol/style/Style.js';
-  import Fill from 'ol/style/Fill.js';
-  import Stroke from 'ol/style/Stroke.js';
+  import Style from 'https://esm.run/ol/style/Style.js'
+  import Fill from 'https://esm.run/ol/style/Fill.js'
+  import Stroke from 'https://esm.run/ol/style/Stroke.js'
 
   window.Style = Style;
   window.Fill = Fill;

--- a/storybook/.storybook/preview-head.html
+++ b/storybook/.storybook/preview-head.html
@@ -4,7 +4,25 @@
     height: 400px;
   }
 
+  ol-map {
+    display: block;
+  }
+
   body > #storybook-root > #root-inner {
     height: 95vh;
   }
+
+  #root-inner {
+    flex-direction: column;
+  }
 </style>
+
+<script type="module">
+  import Style from 'ol/style/Style.js';
+  import Fill from 'ol/style/Fill.js';
+  import Stroke from 'ol/style/Stroke.js';
+
+  window.Style = Style;
+  window.Fill = Fill;
+  window.Stroke = Stroke;
+</script>

--- a/storybook/stories/Select.stories.ts
+++ b/storybook/stories/Select.stories.ts
@@ -25,8 +25,8 @@ const defaults: Meta = {
 
 export default defaults
 
-export const Popup: Story = {
-  name: 'Simple overlay popup',
+export const Selecting: Story = {
+  name: 'Selecting features',
   render: ({ map, id = nanoid(), featureSpan = nanoid() }) => html`
 <ol-map id="${id}" ${spread(map)}>
   <ol-layer-geojson url="/countries.geojson"></ol-layer-geojson>

--- a/storybook/stories/Select.stories.ts
+++ b/storybook/stories/Select.stories.ts
@@ -6,6 +6,9 @@ import { spread } from '@open-wc/lit-helpers'
 import '@openlayers-elements/core/ol-map.js'
 import '@openlayers-elements/maps/ol-select.js'
 import '@openlayers-elements/maps/ol-layer-geojson.js'
+import { customAlphabet } from 'nanoid'
+
+const nanoid = customAlphabet('abcdefghijk', 4)
 
 const defaults: Meta = {
   title: 'Core/ol-select',
@@ -24,24 +27,72 @@ export default defaults
 
 export const Popup: Story = {
   name: 'Simple overlay popup',
-  render: ({ map }) => html`
-<ol-map ${spread(map)}>
+  render: ({ map, id = nanoid(), featureSpan = nanoid() }) => html`
+<ol-map id="${id}" ${spread(map)}>
   <ol-layer-geojson url="/countries.geojson"></ol-layer-geojson>
   <ol-select></ol-select>
 </ol-map>
 
-<p>Selected: <span id="feature">nothing</span></p>
+<p>Selected: <span id="${featureSpan}">nothing</span></p>
 
 <script>
-  const span = document.querySelector('#feature')
-  document.querySelector('ol-select')
-    .addEventListener('feature-selected', e => {
-      span.textContent = e.detail.feature.get('name')
-    })
+  (() => {
+    const map = document.getElementById('${id}')
 
-  document.querySelector('ol-select')
-    .addEventListener('feature-unselected', e => {
-      span.textContent = 'nothing'
-    })
+    const span = document.getElementById('${featureSpan}')
+    map.querySelector('ol-select')
+      .addEventListener('feature-selected', e => {
+
+        span.textContent = e.detail.feature.get('name')
+      })
+
+    map.querySelector('ol-select')
+      .addEventListener('feature-unselected', e => {
+        span.textContent = 'nothing'
+      })
+  })()
 </script>`,
+}
+
+export const FeatureStyle: Story = {
+  name: 'Setting feature styles',
+  render: ({ map, id = nanoid() }) => html`
+<ol-map id="${id}" ${spread(map)}>
+  <ol-layer-geojson url="/countries.geojson"></ol-layer-geojson>
+  <ol-select></ol-select>
+</ol-map>
+
+<script>
+  (() => {
+    const map = document.getElementById('${id}')
+
+    map.querySelector('ol-select')
+      .featureStyle = new Style({
+      fill: new Fill({
+        color: 'rgba(255,255,255,0.4)',
+      }),
+      stroke: new Stroke({
+        color: '#ffb15e',
+        width: 5,
+      }),
+    })
+  })()
+</script>`,
+}
+
+export const FeatureStyleAttribute: Story = {
+  name: 'Setting feature styles from attribute',
+  render: ({ map }) => html`
+<ol-map ${spread(map)}>
+  <ol-layer-geojson url="/countries.geojson"></ol-layer-geojson>
+  <ol-select feature-style='{ "Style": {
+    "fill": { "Fill": {
+      "color": "rgba(255,255,255,0.4)"
+    }},
+    "stroke": { "Stroke": {
+      "color": "#ffb15e",
+      "width": 5
+    }}
+  }}'></ol-select>
+</ol-map>`,
 }

--- a/storybook/stories/Select.stories.ts
+++ b/storybook/stories/Select.stories.ts
@@ -64,6 +64,11 @@ export const FeatureStyle: Story = {
 
 <script>
   (() => {
+    // These don't work in Storybook, but you will need them in your code
+    // import Style from 'ol/style/Style.js';
+    // import Fill from 'ol/style/Fill.js';
+    // import Stroke from 'ol/style/Stroke.js';
+
     const map = document.getElementById('${id}')
 
     map.querySelector('ol-select')

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,9 +16,13 @@
     "strictPropertyInitialization": false,
     "skipLibCheck": true,
     "baseUrl": "./",
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "typeRoots": [
+      "./node_modules/@types",
+    ]
   },
   "include": [
+    "./global.d.ts",
     "elements"
   ]
 }


### PR DESCRIPTION
## Related Issue

@ludovicm67 needed to style selected features. Open Layers has that feature but `featureStyle` property is only settable when constructing `Select`. Because element properties cna change, the style is applied when a select event is triggered.

Additionally, I added a small utility [ol-json-style](https://www.npmjs.com/package/ol-json-style) which allows setting the style from HTML attribute. I bundle it to avoid the dependency.

## Describe this PR

A brief description of how this solves the issue.

## Screenshots

Please provide screenshots of the change.

## Alternative Approaches Considered

Did you attempt any other approaches that are not documented in code?

## Checklist before requesting a review

- [x] Information about the PR, including descriptive commits and link to issue
- [x] All tests are passing
  - Run tests locally with: `npm run test`, or view via the CI workflow.
- [x] Includes a changeset, if required.
  - Run `npx changeset`.
